### PR TITLE
feat: Update caves and combat locations (mapdata only) to Wynncraft 2.1

### DIFF
--- a/Data-Storage/raw/content/content_book_dump.json
+++ b/Data-Storage/raw/content/content_book_dump.json
@@ -40,7 +40,7 @@
     {
       "type": "storylineQuest",
       "name": "A Hunter\u0027s Calling",
-      "specialInfo": "Unlocks Hunted Mode",
+      "specialInfo": "§aUnlocks Hunted Mode",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -60,7 +60,7 @@
     {
       "type": "storylineQuest",
       "name": "A Journey Beyond",
-      "specialInfo": "Unlocks Silent Expanse",
+      "specialInfo": "§aUnlocks Silent Expanse",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -80,7 +80,7 @@
     {
       "type": "storylineQuest",
       "name": "A Journey Further",
-      "specialInfo": "Unlocks Dungeon \u0026 Raid",
+      "specialInfo": "§aUnlocks Dungeon \u0026 Raid",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -104,7 +104,7 @@
       "type": "quest",
       "name": "A Marauder\u0027s Dues",
       "specialInfo": "",
-      "description": "§7Talk to Norsten, at §f[437, 77, -5056]§7.",
+      "description": "§7Talk to Norsten, at §f[437, 81, -5057]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -120,14 +120,14 @@
       ],
       "location": {
         "x": 437,
-        "y": 77,
-        "z": -5056
+        "y": 81,
+        "z": -5057
       }
     },
     {
       "type": "quest",
       "name": "A Sandy Scandal",
-      "specialInfo": "Unlocks Almuj Bank",
+      "specialInfo": "",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -138,9 +138,8 @@
         "quests": []
       },
       "rewards": [
-        "22000 XP",
-        "128 Emeralds",
-        "Access to the Almuj Bank"
+        "24000 XP",
+        "256 Emeralds"
       ],
       "location": null
     },
@@ -148,7 +147,7 @@
       "type": "quest",
       "name": "Acquiring Credentials",
       "specialInfo": "",
-      "description": "§7Get a Gavellian Passport at §f[-256, 57, -4983]§7.",
+      "description": "§7Get a Gavellian Passport at §f[-257, 58, -4978]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -164,16 +163,16 @@
         "Access to the Letvus Elevator"
       ],
       "location": {
-        "x": -256,
-        "y": 57,
-        "z": -4983
+        "x": -257,
+        "y": 58,
+        "z": -4978
       }
     },
     {
       "type": "quest",
       "name": "Aldorei\u0027s Secret Part I",
-      "specialInfo": "Unlocks Aldorei Town",
-      "description": "§7Talk to the Elf Guard at §f[-461, 132, -4459]",
+      "specialInfo": "§aUnlocks Aldorei Town",
+      "description": "§7Talk to the Elf Guard at §f[-462, 135, -4460]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -188,15 +187,15 @@
         "Access to Aldorei Valley Proper"
       ],
       "location": {
-        "x": -461,
-        "y": 132,
-        "z": -4459
+        "x": -462,
+        "y": 135,
+        "z": -4460
       }
     },
     {
       "type": "storylineQuest",
       "name": "Aldorei\u0027s Secret Part II",
-      "specialInfo": "Unlocks Fast Travel",
+      "specialInfo": "§cUnlocks Fast Travel",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -245,7 +244,7 @@
       "type": "quest",
       "name": "An Iron Heart Part I",
       "specialInfo": "",
-      "description": "§7Speak with Duvale at §f[-1613, 51, -4964]",
+      "description": "§7Speak with Duvale at §f[-1613, 54, -4964]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -261,7 +260,7 @@
       ],
       "location": {
         "x": -1613,
-        "y": 51,
+        "y": 54,
         "z": -4964
       }
     },
@@ -290,7 +289,7 @@
     {
       "type": "storylineQuest",
       "name": "Arachnids\u0027 Ascent",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "§cStoryline",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -306,7 +305,7 @@
       "rewards": [
         "1000 XP",
         "1 Infested Pit Key",
-        "Access to the Infested Pit dungeon"
+        "1 Arakadicus\u0027 Eye"
       ],
       "location": null
     },
@@ -355,7 +354,7 @@
       "type": "quest",
       "name": "Blazing Retribution",
       "specialInfo": "",
-      "description": "§7Speak to Piere in the Llevigar plains at §f[-1851, 56, -4959]",
+      "description": "§7Speak to Piere in the Llevigar plains at §f[-1844, 58, -4951]",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -370,9 +369,9 @@
         "Hide of Poxper"
       ],
       "location": {
-        "x": -1851,
-        "y": 56,
-        "z": -4959
+        "x": -1844,
+        "y": 58,
+        "z": -4951
       }
     },
     {
@@ -398,13 +397,13 @@
     {
       "type": "quest",
       "name": "Canyon Condor",
-      "specialInfo": "Unlocks Upper Mesa",
+      "specialInfo": "§aUnlocks Upper Mesa",
       "description": "",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
       "requirements": {
-        "level": 38,
+        "level": 34,
         "professionLevels": {},
         "quests": []
       },
@@ -477,7 +476,7 @@
     {
       "type": "quest",
       "name": "Corrupted Betrayal",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -491,7 +490,7 @@
         "87725 XP",
         "1024 Emeralds",
         "1 Undergrowth Ruins Key",
-        "Access to the Undergrowth Ruins Dungeon"
+        "1 Slykaar\u0027s Heart"
       ],
       "location": null
     },
@@ -499,7 +498,7 @@
       "type": "quest",
       "name": "Cowfusion",
       "specialInfo": "",
-      "description": "§7Talk to Ranol at §f[768, 45, -5425]",
+      "description": "§7Talk to Ranol at §f[768, 48, -5425]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -516,7 +515,7 @@
       ],
       "location": {
         "x": 768,
-        "y": 45,
+        "y": 48,
         "z": -5425
       }
     },
@@ -624,7 +623,7 @@
     {
       "type": "storylineQuest",
       "name": "Dwarves and Doguns Part I",
-      "specialInfo": "Unlocks Upper Molten Heights",
+      "specialInfo": "§aUnlocks Upper Molten Heights",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -644,7 +643,7 @@
     {
       "type": "storylineQuest",
       "name": "Dwarves and Doguns Part II",
-      "specialInfo": "Unlocks Fast Travel",
+      "specialInfo": "§aUnlocks Fast Travel",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -667,7 +666,7 @@
     {
       "type": "storylineQuest",
       "name": "Dwarves and Doguns Part III",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -689,7 +688,7 @@
     {
       "type": "storylineQuest",
       "name": "Dwarves and Doguns Part IV",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -730,7 +729,7 @@
     {
       "type": "storylineQuest",
       "name": "Elemental Exercise",
-      "specialInfo": "Storyline",
+      "specialInfo": "§cStoryline",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -830,7 +829,7 @@
     {
       "type": "quest",
       "name": "Fate of the Fallen",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -843,14 +842,15 @@
       "rewards": [
         "20000 XP",
         "1 Avalanche",
-        "1 Ice Barrows Dungeon Key"
+        "1 Ice Barrows Dungeon Key",
+        "1 Theorick\u0027s Ice Shard"
       ],
       "location": null
     },
     {
       "type": "quest",
       "name": "Flight in Distress",
-      "specialInfo": "Unlocks Fast Travel",
+      "specialInfo": "§aUnlocks Fast Travel",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -873,7 +873,7 @@
       "type": "quest",
       "name": "Forbidden Prison",
       "specialInfo": "",
-      "description": "§7Talk to the Merchant at §f[-963, 47, -5280]",
+      "description": "§7Talk to the Merchant at §f[-966, 50, -5281]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -888,9 +888,9 @@
         "Various Ingredients"
       ],
       "location": {
-        "x": -963,
-        "y": 47,
-        "z": -5280
+        "x": -966,
+        "y": 50,
+        "z": -5281
       }
     },
     {
@@ -918,7 +918,7 @@
       "type": "quest",
       "name": "From the Mountains",
       "specialInfo": "",
-      "description": "§7Find out what\u0027s going on at §f[-1366, 42, -4543]",
+      "description": "§7Find out what\u0027s going on at §f[-1366, 46, -4543]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -933,7 +933,7 @@
       ],
       "location": {
         "x": -1366,
-        "y": 42,
+        "y": 46,
         "z": -4543
       }
     },
@@ -961,7 +961,7 @@
       "type": "quest",
       "name": "General\u0027s Orders",
       "specialInfo": "",
-      "description": "§7Speak to Private Tylas outside of Kitrios Barracks at §f[121, 49, -5437]",
+      "description": "§7Speak to Private Tylas outside of Kitrios Barracks at §f[118, 49, -5435]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -975,9 +975,9 @@
         "1 Changeling\u0027s Chestplate"
       ],
       "location": {
-        "x": 121,
+        "x": 118,
         "y": 49,
-        "z": -5437
+        "z": -5435
       }
     },
     {
@@ -1082,7 +1082,7 @@
       "type": "quest",
       "name": "Hollow Serenity",
       "specialInfo": "",
-      "description": "§7Something seems off in the abandoned manor at §f[-826, 45, -5145]§7.",
+      "description": "§7Something seems off in the abandoned manor at §f[-826, 47, -5146]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -1098,15 +1098,15 @@
       ],
       "location": {
         "x": -826,
-        "y": 45,
-        "z": -5145
+        "y": 47,
+        "z": -5146
       }
     },
     {
       "type": "quest",
       "name": "Hunger of the Gerts Part I",
       "specialInfo": "",
-      "description": "§7Talk to Cikal at §f[-27, 73, -5413]",
+      "description": "§7Talk to Cikal at §f[-27, 76, -5413]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -1120,7 +1120,7 @@
       ],
       "location": {
         "x": -27,
-        "y": 73,
+        "y": 76,
         "z": -5413
       }
     },
@@ -1169,8 +1169,8 @@
     {
       "type": "storylineQuest",
       "name": "Infested Plants",
-      "specialInfo": "Storyline",
-      "description": "§7Meet up with Tasim at the entrance to Nivla Woods at §f[-424, 68, -1595]§7.",
+      "specialInfo": "§eStoryline",
+      "description": "§7Meet up with Tasim at the entrance to Nivla Woods at §f[-424, 71, -1595]§7.",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -1186,7 +1186,7 @@
       ],
       "location": {
         "x": -424,
-        "y": 68,
+        "y": 71,
         "z": -1595
       }
     },
@@ -1213,7 +1213,7 @@
     {
       "type": "storylineQuest",
       "name": "King\u0027s Recruit",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1234,7 +1234,7 @@
     {
       "type": "quest",
       "name": "Kingdom of Sand",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1247,7 +1247,8 @@
       "rewards": [
         "10000 XP",
         "192 Emeralds",
-        "1 Sand-Swept Tomb Dungeon Key"
+        "1 Sand-Swept Tomb Dungeon Key",
+        "1 Hashr\u0027s Bone"
       ],
       "location": null
     },
@@ -1275,7 +1276,7 @@
       "type": "quest",
       "name": "Lazarus Pit",
       "specialInfo": "",
-      "description": "§7Speak to Burtur at §f[-1025, 47, -5302]§7.",
+      "description": "§7Speak to Burtur at §f[-1025, 50, -5302]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -1291,7 +1292,7 @@
       ],
       "location": {
         "x": -1025,
-        "y": 47,
+        "y": 50,
         "z": -5302
       }
     },
@@ -1299,8 +1300,8 @@
       "type": "quest",
       "name": "Lexdale Witch Trials",
       "specialInfo": "",
-      "description": "§7See what\u0027s going on in the center of Lexdale at §f[-604, 45, -5444]§7.",
-      "length": "long",
+      "description": "§7See what\u0027s going on in the center of Lexdale at §f[-603, 63, -5443]§7.",
+      "length": "medium",
       "lengthInfo": "",
       "difficulty": "hard",
       "requirements": {
@@ -1314,9 +1315,9 @@
         "Access to the Lexdale Accessory Merchant"
       ],
       "location": {
-        "x": -604,
-        "y": 45,
-        "z": -5444
+        "x": -603,
+        "y": 63,
+        "z": -5443
       }
     },
     {
@@ -1406,7 +1407,7 @@
       "description": "",
       "length": "short",
       "lengthInfo": "",
-      "difficulty": "medium",
+      "difficulty": "hard",
       "requirements": {
         "level": 10,
         "professionLevels": {},
@@ -1479,7 +1480,7 @@
       "type": "quest",
       "name": "Misadventure on the Sea",
       "specialInfo": "",
-      "description": "§7Visit the Nemract bar at §f[114, 40, -2176]",
+      "description": "§7Visit the Nemract bar at §f[118, 41, -2176]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -1495,8 +1496,8 @@
         "Various Ingredients"
       ],
       "location": {
-        "x": 114,
-        "y": 40,
+        "x": 118,
+        "y": 41,
         "z": -2176
       }
     },
@@ -1542,7 +1543,7 @@
     {
       "type": "storylineQuest",
       "name": "Mushroom Man",
-      "specialInfo": "Storyline",
+      "specialInfo": "§cStoryline",
       "description": "",
       "length": "short",
       "lengthInfo": "",
@@ -1563,7 +1564,7 @@
     {
       "type": "quest",
       "name": "One Thousand Meters Under",
-      "specialInfo": "Unlocks The Void",
+      "specialInfo": "§aUnlocks The Void",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1720,7 +1721,7 @@
     {
       "type": "storylineQuest",
       "name": "Realm of Light I - The Worm Holes",
-      "specialInfo": "Unlocks Raid",
+      "specialInfo": "§aUnlocks Raid",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1743,7 +1744,7 @@
     {
       "type": "storylineQuest",
       "name": "Realm of Light II - Taproot",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1765,7 +1766,7 @@
     {
       "type": "storylineQuest",
       "name": "Realm of Light III - A Headless History",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1786,7 +1787,7 @@
     {
       "type": "storylineQuest",
       "name": "Realm of Light IV - Finding the Light",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1808,7 +1809,7 @@
     {
       "type": "storylineQuest",
       "name": "Realm of Light V - The Realm of Light",
-      "specialInfo": "Unlocks Raid",
+      "specialInfo": "§aUnlocks Raid",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1831,8 +1832,8 @@
     {
       "type": "quest",
       "name": "Recipe For Disaster",
-      "specialInfo": "Unlocks Fast Travel",
-      "description": "§7Meet up with Chef Hamsey in Ahmsord at §f[949, 129, -4475]",
+      "specialInfo": "§eUnlocks Fast Travel",
+      "description": "§7Meet up with Chef Hamsey in Ahmsord at §f[949, 132, -4475]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -1849,7 +1850,7 @@
       ],
       "location": {
         "x": 949,
-        "y": 129,
+        "y": 132,
         "z": -4475
       }
     },
@@ -1857,7 +1858,7 @@
       "type": "quest",
       "name": "Reclaiming the House",
       "specialInfo": "",
-      "description": "§7Join Elphaba on a mission in the Temporary Camp at §f[-1499, 47, -5349]§7.",
+      "description": "§7Join Elphaba on a mission in the Temporary Camp at §f[-1500, 50, -5350]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -1871,16 +1872,16 @@
         "1024 Emeralds"
       ],
       "location": {
-        "x": -1499,
-        "y": 47,
-        "z": -5349
+        "x": -1500,
+        "y": 50,
+        "z": -5350
       }
     },
     {
       "type": "storylineQuest",
       "name": "Recover the Past",
-      "specialInfo": "Unlocks Ability Resets",
-      "description": "§7Talk to Dr. Picard at §f[103, 90, -1200]§7.",
+      "specialInfo": "§aUnlocks Ability Resets",
+      "description": "§7Talk to Dr. Picard at §f[103, 93, -1200]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -1897,14 +1898,14 @@
       ],
       "location": {
         "x": 103,
-        "y": 90,
+        "y": 93,
         "z": -1200
       }
     },
     {
       "type": "quest",
       "name": "Redbeard\u0027s Booty",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -1916,9 +1917,9 @@
       },
       "rewards": [
         "180000 XP",
-        "1 Galleon\u0027s Graveyard Key",
         "1 Golden Pirate Fish",
-        "Access to the Galleon\u0027s Graveyard dungeon"
+        "1 Galleon\u0027s Graveyard Key",
+        "1 Redbeard\u0027s Hair"
       ],
       "location": null
     },
@@ -1969,7 +1970,7 @@
       "type": "quest",
       "name": "Royal Trials",
       "specialInfo": "",
-      "description": "§7Talk to the Skyraider Guard at §f[1479, 84, -4343]",
+      "description": "§7Talk to the Skyraider Guard at §f[1479, 87, -4343]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -1985,7 +1986,7 @@
       ],
       "location": {
         "x": 1479,
-        "y": 84,
+        "y": 87,
         "z": -4343
       }
     },
@@ -1993,7 +1994,7 @@
       "type": "quest",
       "name": "Shattered Minds",
       "specialInfo": "",
-      "description": "§7Speak to Likeru in Efilim at §f[-1058, 44, -5008]§7.",
+      "description": "§7Speak to Likeru in Efilim at §f[-1058, 46, -5006]§7.",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -2009,14 +2010,14 @@
       ],
       "location": {
         "x": -1058,
-        "y": 44,
-        "z": -5008
+        "y": 46,
+        "z": -5006
       }
     },
     {
       "type": "quest",
       "name": "Stable Story",
-      "specialInfo": "Unlock Horses",
+      "specialInfo": "§aUnlock Horses",
       "description": "",
       "length": "short",
       "lengthInfo": "",
@@ -2055,7 +2056,7 @@
     {
       "type": "quest",
       "name": "Supply and Delivery",
-      "specialInfo": "Unlocks Fast Travel",
+      "specialInfo": "§cUnlocks Fast Travel",
       "description": "",
       "length": "short",
       "lengthInfo": "",
@@ -2077,7 +2078,7 @@
     {
       "type": "storylineQuest",
       "name": "Taking the Tower",
-      "specialInfo": "Storyline",
+      "specialInfo": "§cStoryline",
       "description": "",
       "length": "short",
       "lengthInfo": "",
@@ -2119,8 +2120,8 @@
     {
       "type": "quest",
       "name": "Tempo Town Trouble",
-      "specialInfo": "Unlocks Fast Travel",
-      "description": "§7Talk to Tyko at §f[87, 39, -2199]",
+      "specialInfo": "§eUnlocks Fast Travel",
+      "description": "§7Talk to Tyko at §f[87, 42, -2199]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -2137,7 +2138,7 @@
       ],
       "location": {
         "x": 87,
-        "y": 39,
+        "y": 42,
         "z": -2199
       }
     },
@@ -2165,7 +2166,7 @@
     {
       "type": "storylineQuest",
       "name": "The Breaking Point",
-      "specialInfo": "Unlocks Raid",
+      "specialInfo": "§cUnlocks Raid",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -2192,7 +2193,7 @@
       "type": "quest",
       "name": "The Canary Calls",
       "specialInfo": "",
-      "description": "§7Find out what\u0027s happening outside the Thesead coal mine at §f[677, 78, -5017]",
+      "description": "§7Find out what\u0027s happening outside the Thesead coal mine at §f[677, 80, -5017]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -2207,7 +2208,7 @@
       ],
       "location": {
         "x": 677,
-        "y": 78,
+        "y": 80,
         "z": -5017
       }
     },
@@ -2215,7 +2216,7 @@
       "type": "quest",
       "name": "The Canyon Guides",
       "specialInfo": "",
-      "description": "§7Speak to Gana at §f[426, 101, -4829]",
+      "description": "§7Speak to Gana at §f[426, 104, -4830]",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -2230,8 +2231,8 @@
       ],
       "location": {
         "x": 426,
-        "y": 101,
-        "z": -4829
+        "y": 104,
+        "z": -4830
       }
     },
     {
@@ -2256,7 +2257,7 @@
     {
       "type": "quest",
       "name": "The Dark Descent",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -2270,14 +2271,14 @@
         "2400 XP",
         "Dark Diadem",
         "1 Underworld Crypt Key",
-        "Access to the Underworld Crypt Dungeon"
+        "1 Charon\u0027s Brain"
       ],
       "location": null
     },
     {
       "type": "storylineQuest",
       "name": "The Envoy Part I",
-      "specialInfo": "Unlocks Corkus",
+      "specialInfo": "§aUnlocks Corkus",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -2297,7 +2298,7 @@
     {
       "type": "storylineQuest",
       "name": "The Envoy Part II",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "§aUnlocks Dungeon",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -2321,8 +2322,8 @@
     {
       "type": "storylineQuest",
       "name": "The Feathers Fly Part I",
-      "specialInfo": "Storyline",
-      "description": "§7Visit the Workshop at §f[-1731, 134, -3267]§7 (Requires completion of The Envoy Part II)",
+      "specialInfo": "§eStoryline",
+      "description": "§7Visit the Workshop at §f[-1731, 135, -3268]§7 (Requires completion of The Envoy Part II)",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -2340,14 +2341,14 @@
       ],
       "location": {
         "x": -1731,
-        "y": 134,
-        "z": -3267
+        "y": 135,
+        "z": -3268
       }
     },
     {
       "type": "storylineQuest",
       "name": "The Feathers Fly Part II",
-      "specialInfo": "Storyline",
+      "specialInfo": "§cStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -2373,7 +2374,7 @@
       "type": "quest",
       "name": "The Hero of Gavel",
       "specialInfo": "",
-      "description": "§7Get a Siegfried Scavenger Hunt ticket in the center of Ahmsord at §f[1034, 115, -4533]",
+      "description": "§7Get a Siegfried Scavenger Hunt ticket in the center of Ahmsord at §f[1036, 118, -4531]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -2387,16 +2388,16 @@
         "20480 Emeralds"
       ],
       "location": {
-        "x": 1034,
-        "y": 115,
-        "z": -4533
+        "x": 1036,
+        "y": 118,
+        "z": -4531
       }
     },
     {
       "type": "quest",
       "name": "The Hidden City",
-      "specialInfo": "Unlocks Eltom",
-      "description": "§7Talk to Thesead\u0027s Mayor at §f[857, 112, -5040]§7 at the top of Thesead",
+      "specialInfo": "§aUnlocks Eltom",
+      "description": "§7Talk to Thesead\u0027s Mayor at §f[857, 116, -5041]§7 at the top of Thesead",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -2413,8 +2414,8 @@
       ],
       "location": {
         "x": 857,
-        "y": 112,
-        "z": -5040
+        "y": 116,
+        "z": -5041
       }
     },
     {
@@ -2440,7 +2441,7 @@
       "type": "quest",
       "name": "The Lost",
       "specialInfo": "",
-      "description": "§7Find Dejol at §f[452, 28, -4456]",
+      "description": "§7Find Dejol at §f[447, 31, -4461]",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -2455,9 +2456,9 @@
         "1 Canyon Chart"
       ],
       "location": {
-        "x": 452,
-        "y": 28,
-        "z": -4456
+        "x": 447,
+        "y": 31,
+        "z": -4461
       }
     },
     {
@@ -2483,7 +2484,7 @@
       "type": "quest",
       "name": "The Mercenary",
       "specialInfo": "",
-      "description": "",
+      "description": "§7Talk to the Scout in Detlas at §f[482, 70, -1585]§7 or find one in another town.",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -2497,12 +2498,16 @@
         "384 Emeralds",
         "Vindicator"
       ],
-      "location": null
+      "location": {
+        "x": 482,
+        "y": 70,
+        "z": -1585
+      }
     },
     {
       "type": "quest",
       "name": "The Olmic Rune",
-      "specialInfo": "Unlocks Tol Rune Altar",
+      "specialInfo": "§aUnlocks Tol Rune Altar",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -2523,8 +2528,8 @@
     {
       "type": "quest",
       "name": "The Order of the Grook",
-      "specialInfo": "Unlocks Fast Travel",
-      "description": "§7Talk to Seasum on Mage Island at §f[940, 77, -2866]",
+      "specialInfo": "§eUnlocks Fast Travel",
+      "description": "§7Talk to Seasum on Mage Island at §f[940, 79, -2866]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -2540,14 +2545,14 @@
       ],
       "location": {
         "x": 940,
-        "y": 77,
+        "y": 79,
         "z": -2866
       }
     },
     {
       "type": "quest",
       "name": "The Passage",
-      "specialInfo": "Unlocks Fast Travel",
+      "specialInfo": "§aUnlocks Fast Travel",
       "description": "",
       "length": "short",
       "lengthInfo": "",
@@ -2586,7 +2591,7 @@
     {
       "type": "quest",
       "name": "The Sewers of Ragni",
-      "specialInfo": "Unlocks Dungeon",
+      "specialInfo": "",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -2597,10 +2602,10 @@
         "quests": []
       },
       "rewards": [
-        "350 XP",
+        "450 XP",
         "1 Thoracic",
         "1 Decrepit Sewers Dungeon Key",
-        "Access to the Decrepit Sewers Dungeon"
+        "1 Witherhead\u0027s Rib"
       ],
       "location": null
     },
@@ -2615,9 +2620,9 @@
       "requirements": {
         "level": 54,
         "professionLevels": {
+          "woodcutting": 20,
           "mining": 20,
-          "fishing": 20,
-          "woodcutting": 20
+          "fishing": 20
         },
         "quests": []
       },
@@ -2634,7 +2639,7 @@
       "type": "quest",
       "name": "The Thanos Depository",
       "specialInfo": "",
-      "description": "§7Find out what\u0027s happening at §f[167, 6, -5184]",
+      "description": "§7Find out what\u0027s happening at §f[167, 7, -5174]",
       "length": "long",
       "lengthInfo": "",
       "difficulty": "hard",
@@ -2650,15 +2655,15 @@
       ],
       "location": {
         "x": 167,
-        "y": 6,
-        "z": -5184
+        "y": 7,
+        "z": -5174
       }
     },
     {
       "type": "quest",
       "name": "The Ultimate Weapon",
       "specialInfo": "",
-      "description": "§7Speak to Dodegar Bandysnoot at §f[-987, 42, -4593]",
+      "description": "§7Speak to Dodegar Bandysnoot at §f[-987, 44, -4591]",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "medium",
@@ -2675,8 +2680,8 @@
       ],
       "location": {
         "x": -987,
-        "y": 42,
-        "z": -4593
+        "y": 44,
+        "z": -4591
       }
     },
     {
@@ -2740,7 +2745,7 @@
     {
       "type": "quest",
       "name": "Tunnel Trouble",
-      "specialInfo": "Unlocks Fast Travel",
+      "specialInfo": "§aUnlocks Fast Travel",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -2827,7 +2832,7 @@
     {
       "type": "storylineQuest",
       "name": "WynnExcavation Site A",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -2846,7 +2851,7 @@
     {
       "type": "storylineQuest",
       "name": "WynnExcavation Site B",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -2868,7 +2873,7 @@
     {
       "type": "storylineQuest",
       "name": "WynnExcavation Site C",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "medium",
       "lengthInfo": "",
@@ -2889,7 +2894,7 @@
     {
       "type": "storylineQuest",
       "name": "WynnExcavation Site D",
-      "specialInfo": "Storyline",
+      "specialInfo": "§aStoryline",
       "description": "",
       "length": "long",
       "lengthInfo": "",
@@ -3082,7 +3087,7 @@
       "type": "miniQuest",
       "name": "Gather Barley",
       "specialInfo": "",
-      "description": "§7Bring §3[14 Barley String]§7 or §3[14 Barley Grains]§7 to the Gathering Post §3[Farming Lv. 18] §7at §f[-539, 101, -1306]",
+      "description": "§7Bring §3[14 Barley String]§7 or §3[14 Barley Grains]§7 to the Gathering Post §3[Farming Lv. 18]§7 at §f[-539, 105, -1306]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -3099,7 +3104,7 @@
       ],
       "location": {
         "x": -539,
-        "y": 101,
+        "y": 105,
         "z": -1306
       }
     },
@@ -3191,7 +3196,7 @@
       "type": "miniQuest",
       "name": "Gather Birch Logs",
       "specialInfo": "",
-      "description": "§7Bring §3[14 Birch Wood]§7 or §3[14 Birch Paper]§7 to the Gathering Post §3[Woodcutting Lv. 18]§7 at §f[182, 67, -1597]",
+      "description": "§7Bring §3[14 Birch Wood]§7 or §3[14 Birch Paper]§7 to the Gathering Post §3[Woodcutting Lv. 18]§7 at §f[182, 71, -1597]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -3208,7 +3213,7 @@
       ],
       "location": {
         "x": 182,
-        "y": 67,
+        "y": 71,
         "z": -1597
       }
     },
@@ -3321,7 +3326,7 @@
       "type": "miniQuest",
       "name": "Gather Copper",
       "specialInfo": "",
-      "description": "§7Bring §3[12 Copper Ingots]§7 or §3[12 Copper Gems]§7 to the Gathering Post §3[Mining Lv. 8]§7 at §f[-563, 68, -1547]",
+      "description": "§7Bring §3[12 Copper Ingots]§7 or §3[12 Copper Gems]§7 to the Gathering Post §3[Mining Lv. 8]§7 at §f[-563, 72, -1547]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -3338,7 +3343,7 @@
       ],
       "location": {
         "x": -563,
-        "y": 68,
+        "y": 72,
         "z": -1547
       }
     },
@@ -3598,7 +3603,7 @@
       "type": "miniQuest",
       "name": "Gather Granite",
       "specialInfo": "",
-      "description": "§7Bring §3[14 Granite Ingots]§7 or §3[14 Granite Gems]§7 to the Gathering Post §3[Mining Lv. 18] §7at §f[-879, 111, -1330]",
+      "description": "§7Bring §3[14 Granite Ingots]§7 or §3[14 Granite Gems]§7 to the Gathering Post §3[Mining Lv. 18] §7at §f[-879, 115, -1330]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -3615,7 +3620,7 @@
       ],
       "location": {
         "x": -879,
-        "y": 111,
+        "y": 115,
         "z": -1330
       }
     },
@@ -3623,7 +3628,7 @@
       "type": "miniQuest",
       "name": "Gather Gudgeon",
       "specialInfo": "",
-      "description": "§7Bring §3[12 Gudgeon Oil]§7 or §3[12 Gudgeon Meat]§7 to the Gathering Post §3[Fishing Lv. 8] §7at §f[-637, 67, -1558]",
+      "description": "§7Bring §3[12 Gudgeon Oil]§7 or §3[12 Gudgeon Meat]§7 to the Gathering Post §3[Fishing Lv. 8]§7 at §f[-637, 71, -1558]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -3640,7 +3645,7 @@
       ],
       "location": {
         "x": -637,
-        "y": 67,
+        "y": 71,
         "z": -1558
       }
     },
@@ -4341,7 +4346,7 @@
       "type": "miniQuest",
       "name": "Gather Oak Logs",
       "specialInfo": "",
-      "description": "§7Bring §3[12 Oak Wood]§7 or §3[12 Oak Paper]§7 to the Gathering Post §3[Woodcutting Lv. 8]§7 at §f[-433, 67, -1591]",
+      "description": "§7Bring §3[12 Oak Wood]§7 or §3[12 Oak Paper]§7 to the Gathering Post §3[Woodcutting Lv. 8]§7 at §f[-433, 71, -1591]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -4358,7 +4363,7 @@
       ],
       "location": {
         "x": -433,
-        "y": 67,
+        "y": 71,
         "z": -1591
       }
     },
@@ -4891,7 +4896,7 @@
       "type": "miniQuest",
       "name": "Gather Trout",
       "specialInfo": "",
-      "description": "§7Bring §3[14 Trout Oil]§7 or §3[14 Trout Meat]§7 to the Gathering Post §3[Fishing Lv. 18]§7 at §f[53, 60, -1547]",
+      "description": "§7Bring §3[14 Trout Oil]§7 or §3[14 Trout Meat]§7 to the Gathering Post §3[Fishing Lv. 18]§7 at §f[53, 64, -1547]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -4908,7 +4913,7 @@
       ],
       "location": {
         "x": 53,
-        "y": 60,
+        "y": 64,
         "z": -1547
       }
     },
@@ -4916,7 +4921,7 @@
       "type": "miniQuest",
       "name": "Gather Wheat",
       "specialInfo": "",
-      "description": "§7Bring §3[12 Wheat String]§7 or §3[12 Wheat Grains]§7 to the Gathering Post §3[Farming Lv. 8] §7at §f[-781, 66, -1742]",
+      "description": "§7Bring §3[12 Wheat String]§7 or §3[12 Wheat Grains]§7 to the Gathering Post §3[Farming Lv. 8]§7 at §f[-781, 70, -1742]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -4933,7 +4938,7 @@
       ],
       "location": {
         "x": -781,
-        "y": 66,
+        "y": 70,
         "z": -1742
       }
     },
@@ -4983,7 +4988,7 @@
       "type": "miniQuest",
       "name": "Slay Ailuropodas",
       "specialInfo": "",
-      "description": "§7Bring §3[24 Fluffy Fur]§7 to the Slaying Post §3[Combat Lv. 88]§7 at §f[139, 58, -4399]",
+      "description": "§7Bring §3[24 Fluffy Fur]§7 to the Slaying Post §3[Combat Lv. 88]§7 at §f[139, 61, -4399]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -4997,7 +5002,7 @@
       ],
       "location": {
         "x": 139,
-        "y": 58,
+        "y": 61,
         "z": -4399
       }
     },
@@ -5005,7 +5010,7 @@
       "type": "miniQuest",
       "name": "Slay Angels",
       "specialInfo": "",
-      "description": "§7Bring §3[25 Holy Powders]§7 to the Slaying Post §3[Combat Lv. 98]§7 at §f[1005, 118, -4790]",
+      "description": "§7Bring §3[25 Holy Powders]§7 to the Slaying Post §3[Combat Lv. 98]§7 at §f[1005, 122, -4790]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5019,7 +5024,7 @@
       ],
       "location": {
         "x": 1005,
-        "y": 118,
+        "y": 122,
         "z": -4790
       }
     },
@@ -5027,7 +5032,7 @@
       "type": "miniQuest",
       "name": "Slay Astrochelys Manis",
       "specialInfo": "",
-      "description": "§7Bring §3[20 Manis Carapaces]§7 to the Slaying Post §3[Combat Lv. 95] §7at §f[-1422, 138, -3225]",
+      "description": "§7Bring §3[20 Manis Carapaces]§7 to the Slaying Post §3[Combat Lv. 95]§7 at §f[-1422, 140, -3225]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5041,7 +5046,7 @@
       ],
       "location": {
         "x": -1422,
-        "y": 138,
+        "y": 140,
         "z": -3225
       }
     },
@@ -5049,7 +5054,7 @@
       "type": "miniQuest",
       "name": "Slay Azers",
       "specialInfo": "",
-      "description": "§7Bring §3[22 Broken Helmets]§7 to the Slaying Post §3[Combat Lv. 93] §7at §f[1483, 23, -5115]",
+      "description": "§7Bring §3[22 Broken Helmets]§7 to the Slaying Post §3[Combat Lv. 93]§7 at §f[1483, 27, -5115]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5063,7 +5068,7 @@
       ],
       "location": {
         "x": 1483,
-        "y": 23,
+        "y": 27,
         "z": -5115
       }
     },
@@ -5071,7 +5076,7 @@
       "type": "miniQuest",
       "name": "Slay Conures",
       "specialInfo": "",
-      "description": "§7Bring §3[20 Silver Feathers]§7 to the Slaying Post §3[Combat Lv. 97] §7at §f[1123, 141, -4436]",
+      "description": "§7Bring §3[20 Silver Feathers]§7 to the Slaying Post §3[Combat Lv. 97]§7 at §f[1123, 145, -4436]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5085,7 +5090,7 @@
       ],
       "location": {
         "x": 1123,
-        "y": 141,
+        "y": 145,
         "z": -4436
       }
     },
@@ -5093,7 +5098,7 @@
       "type": "miniQuest",
       "name": "Slay Coyotes",
       "specialInfo": "",
-      "description": "§7Bring §3[16 Coyote Fangs]§7 to the Slaying Post §3[Combat Lv. 35]§7 at §f[1200, 30, -1332]",
+      "description": "§7Bring §3[16 Coyote Fangs]§7 to the Slaying Post §3[Combat Lv. 35]§7 at §f[1200, 34, -1332]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5107,7 +5112,7 @@
       ],
       "location": {
         "x": 1200,
-        "y": 30,
+        "y": 34,
         "z": -1332
       }
     },
@@ -5115,7 +5120,7 @@
       "type": "miniQuest",
       "name": "Slay Creatures of Nesaak Forest",
       "specialInfo": "",
-      "description": "§7Bring §3[15 Snow Clumps]§7 to the Slaying Post §3[Combat Lv. 40]§7 at §f[82, 69, -725]",
+      "description": "§7Bring §3[15 Snow Clumps]§7 to the Slaying Post §3[Combat Lv. 40]§7 at §f[82, 73, -725]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5129,7 +5134,7 @@
       ],
       "location": {
         "x": 82,
-        "y": 69,
+        "y": 73,
         "z": -725
       }
     },
@@ -5137,7 +5142,7 @@
       "type": "miniQuest",
       "name": "Slay Creatures of the Void",
       "specialInfo": "",
-      "description": "§7Bring §3[20 Void Essences]§7 to the Slaying Post §3[Combat Lv. 96] §7at §f[14028, 118, -4226]",
+      "description": "§7Bring §3[20 Void Essences]§7 to the Slaying Post §3[Combat Lv. 96]§7 at §f[14028, 122, -4226]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5151,7 +5156,7 @@
       ],
       "location": {
         "x": 14028,
-        "y": 118,
+        "y": 122,
         "z": -4226
       }
     },
@@ -5159,7 +5164,7 @@
       "type": "miniQuest",
       "name": "Slay Dead Villagers",
       "specialInfo": "",
-      "description": "§7Bring §3[16 Severed Hearts]§7 to the Slaying Post §3[Combat Lv. 70] §7at §f[762, 35, -3890]",
+      "description": "§7Bring §3[16 Severed Hearts]§7 to the Slaying Post §3[Combat Lv. 70]§7 at §f[762, 39, -3890]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5173,7 +5178,7 @@
       ],
       "location": {
         "x": 762,
-        "y": 35,
+        "y": 39,
         "z": -3890
       }
     },
@@ -5181,7 +5186,7 @@
       "type": "miniQuest",
       "name": "Slay Dragonlings",
       "specialInfo": "",
-      "description": "§7Bring §3[15 Dragonling Scales] §7to the Slaying Post §3[Combat Lv. 99]§7 at §f[1348, 124, -4470]",
+      "description": "§7Bring §3[15 Dragonling Scales]§7 to the Slaying Post §3[Combat Lv. 99]§7 at §f[1348, 128, -4470]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5195,7 +5200,7 @@
       ],
       "location": {
         "x": 1348,
-        "y": 124,
+        "y": 128,
         "z": -4470
       }
     },
@@ -5203,7 +5208,7 @@
       "type": "miniQuest",
       "name": "Slay Felrocs",
       "specialInfo": "",
-      "description": "§7Bring §3[18 Pure Rain Stone]§7 to the Slaying Post §3[Combat Lv. 78] §7at §f[-163, 33, -4812]",
+      "description": "§7Bring §3[18 Pure Rain Stone]§7 to the Slaying Post §3[Combat Lv. 78]§7 at §f[-163, 37, -4812]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5217,7 +5222,7 @@
       ],
       "location": {
         "x": -163,
-        "y": 33,
+        "y": 37,
         "z": -4812
       }
     },
@@ -5225,7 +5230,7 @@
       "type": "miniQuest",
       "name": "Slay Frosted Guards \u0026 Cryostone Golems",
       "specialInfo": "",
-      "description": "§7Bring §3[30 Unmeltable Ice]§7 to the Slaying Post §3[Combat Lv. 92] §7at §f[1423, 7, -5448]",
+      "description": "§7Bring §3[30 Unmeltable Ice]§7 to the Slaying Post §3[Combat Lv. 92]§7 at §f[1423, 11, -5448]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5239,7 +5244,7 @@
       ],
       "location": {
         "x": 1423,
-        "y": 7,
+        "y": 11,
         "z": -5448
       }
     },
@@ -5247,7 +5252,7 @@
       "type": "miniQuest",
       "name": "Slay Hobgoblins",
       "specialInfo": "",
-      "description": "§7Bring §3[22 Goblin Teeth]§7 to the Slaying Post §3[Combat Lv. 80]§7 at §f[562, 26, -5421]",
+      "description": "§7Bring §3[22 Goblin Teeth]§7 to the Slaying Post §3[Combat Lv. 80]§7 at §f[562, 30, -5421]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5261,7 +5266,7 @@
       ],
       "location": {
         "x": 562,
-        "y": 26,
+        "y": 30,
         "z": -5421
       }
     },
@@ -5269,7 +5274,7 @@
       "type": "miniQuest",
       "name": "Slay Idols",
       "specialInfo": "",
-      "description": "§7Bring §3[18 Ancient Metal]§7 to the Slaying Post §3[Combat Lv. 65] §7at §f[-708, 28, -413]",
+      "description": "§7Bring §3[18 Ancient Metal]§7 to the Slaying Post §3[Combat Lv. 65]§7 at §f[-708, 32, -413]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5283,7 +5288,7 @@
       ],
       "location": {
         "x": -708,
-        "y": 28,
+        "y": 32,
         "z": -413
       }
     },
@@ -5291,7 +5296,7 @@
       "type": "miniQuest",
       "name": "Slay Ifrits",
       "specialInfo": "",
-      "description": "§7Bring §3[15 Demonic Ashes]§7 to the Slaying Post §3[Combat Lv. 94] §7at §f[1389, 156, -5476]",
+      "description": "§7Bring §3[15 Demonic Ashes]§7 to the Slaying Post §3[Combat Lv. 94]§7 at §f[1389, 160, -5476]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5305,7 +5310,7 @@
       ],
       "location": {
         "x": 1389,
-        "y": 156,
+        "y": 160,
         "z": -5476
       }
     },
@@ -5313,7 +5318,7 @@
       "type": "miniQuest",
       "name": "Slay Jinkos",
       "specialInfo": "",
-      "description": "§7Bring §3[22 Sharp Claws]§7 to the Slaying Post §3[Combat Lv. 83]§7 at §f[549, 27, -4996]",
+      "description": "§7Bring §3[22 Sharp Claws]§7 to the Slaying Post §3[Combat Lv. 83]§7 at §f[549, 31, -4996]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5327,7 +5332,7 @@
       ],
       "location": {
         "x": 549,
-        "y": 27,
+        "y": 31,
         "z": -4996
       }
     },
@@ -5335,7 +5340,7 @@
       "type": "miniQuest",
       "name": "Slay Lizardmen",
       "specialInfo": "",
-      "description": "§7Bring §3[16 Lizard Scales]§7 to the Slaying Post §3[Combat Lv. 55] §7at §f[-1786, 60, -5267]",
+      "description": "§7Bring §3[16 Lizard Scales]§7 to the Slaying Post §3[Combat Lv. 55]§7 at §f[-1786, 64, -5267]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5349,7 +5354,7 @@
       ],
       "location": {
         "x": -1786,
-        "y": 60,
+        "y": 64,
         "z": -5267
       }
     },
@@ -5357,7 +5362,7 @@
       "type": "miniQuest",
       "name": "Slay Magma Entities",
       "specialInfo": "",
-      "description": "§7Bring §3[16 Acid Magma]§7 to the Slaying Post §3[Combat Lv. 91]§7 at §f[1266, 15, -5329]",
+      "description": "§7Bring §3[16 Acid Magma]§7 to the Slaying Post §3[Combat Lv. 91]§7 at §f[1266, 19, -5329]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5371,7 +5376,7 @@
       ],
       "location": {
         "x": 1266,
-        "y": 15,
+        "y": 19,
         "z": -5329
       }
     },
@@ -5397,7 +5402,7 @@
       "type": "miniQuest",
       "name": "Slay Myconids",
       "specialInfo": "",
-      "description": "§7Bring §3[22 Myconid Spores]§7 to the Slaying Post §3[Combat Lv. 73] §7at §f[-984, 42, -4637]",
+      "description": "§7Bring §3[22 Myconid Spores]§7 to the Slaying Post §3[Combat Lv. 73]§7 at §f[-984, 46, -4637]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5411,7 +5416,7 @@
       ],
       "location": {
         "x": -984,
-        "y": 42,
+        "y": 46,
         "z": -4637
       }
     },
@@ -5419,7 +5424,7 @@
       "type": "miniQuest",
       "name": "Slay Orcs",
       "specialInfo": "",
-      "description": "§7Bring §3[16 Orc Eyes]§7 to the Slaying Post §3[Combat Lv. 45]§7 at §f[-2006, 33, -4655]",
+      "description": "§7Bring §3[16 Orc Eyes]§7 to the Slaying Post §3[Combat Lv. 45]§7 at §f[-2002, 37, -4653]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5432,16 +5437,16 @@
         "20160 XP"
       ],
       "location": {
-        "x": -2006,
-        "y": 33,
-        "z": -4655
+        "x": -2002,
+        "y": 37,
+        "z": -4653
       }
     },
     {
       "type": "miniQuest",
       "name": "Slay Pernix Monkeys",
       "specialInfo": "",
-      "description": "§7Bring §3[24 Perkish Potatoes] §7to the Slaying Post §3[Combat Lv. 90]§7 at §f[-1721, 110, -2255]",
+      "description": "§7Bring §3[24 Perkish Potatoes]§7 to the Slaying Post §3[Combat Lv. 90]§7 at §f[-1721, 114, -2255]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5455,7 +5460,7 @@
       ],
       "location": {
         "x": -1721,
-        "y": 110,
+        "y": 114,
         "z": -2255
       }
     },
@@ -5463,7 +5468,7 @@
       "type": "miniQuest",
       "name": "Slay Robots",
       "specialInfo": "",
-      "description": "§7Bring §3[28 Robot Antennas]§7 to the Slaying Post §3[Combat Lv. 85] §7at §f[-1751, 71, -2694]",
+      "description": "§7Bring §3[28 Robot Antennas]§7 to the Slaying Post §3[Combat Lv. 85]§7 at §f[-1751, 75, -2694]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5477,7 +5482,7 @@
       ],
       "location": {
         "x": -1751,
-        "y": 71,
+        "y": 75,
         "z": -2694
       }
     },
@@ -5485,7 +5490,7 @@
       "type": "miniQuest",
       "name": "Slay Scarabs",
       "specialInfo": "",
-      "description": "§7Bring §3[16 Mashed Insect]§7 to the Slaying Post §3[Combat Lv. 30] §7at §f[982, 69, -2073]",
+      "description": "§7Bring §3[16 Mashed Insect]§7 to the Slaying Post §3[Combat Lv. 30]§7 at §f[982, 73, -2073]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5499,7 +5504,7 @@
       ],
       "location": {
         "x": 982,
-        "y": 69,
+        "y": 73,
         "z": -2073
       }
     },
@@ -5507,7 +5512,7 @@
       "type": "miniQuest",
       "name": "Slay Skeletons",
       "specialInfo": "",
-      "description": "§7Bring §3[12 Bone Meal]§7 to the Slaying Post §3[Combat Lv. 25]§7 at §f[202, 60, -1787]",
+      "description": "§7Bring §3[12 Bone Meal]§7 to the Slaying Post §3[Combat Lv. 25]§7 at §f[197, 61, -1788]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5520,16 +5525,16 @@
         "3300 XP"
       ],
       "location": {
-        "x": 202,
-        "y": 60,
-        "z": -1787
+        "x": 197,
+        "y": 61,
+        "z": -1788
       }
     },
     {
       "type": "miniQuest",
       "name": "Slay Slimes",
       "specialInfo": "",
-      "description": "§7Bring §3[22 Viscous Slime]§7 to the Slaying Post §3[Combat Lv. 50] §7at §f[-480, 68, -707]",
+      "description": "§7Bring §3[22 Viscous Slime]§7 to the Slaying Post §3[Combat Lv. 50]§7 at §f[-480, 72, -707]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5543,7 +5548,7 @@
       ],
       "location": {
         "x": -480,
-        "y": 68,
+        "y": 72,
         "z": -707
       }
     },
@@ -5551,7 +5556,7 @@
       "type": "miniQuest",
       "name": "Slay Spiders",
       "specialInfo": "",
-      "description": "§7Bring §3[5 Forest Webs]§7 to the Slaying Post §3[Combat Lv. 4]§7 at §f[-272, 70, -1588]",
+      "description": "§7Bring §3[5 Forest Webs]§7 to the Slaying Post §3[Combat Lv. 4]§7 at §f[-272, 73, -1588]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5565,7 +5570,7 @@
       ],
       "location": {
         "x": -272,
-        "y": 70,
+        "y": 73,
         "z": -1588
       }
     },
@@ -5573,7 +5578,7 @@
       "type": "miniQuest",
       "name": "Slay Weirds",
       "specialInfo": "",
-      "description": "§7Bring §3[15 Arcane Anomalies] §7to the Slaying Post §3[Combat Lv. 75]§7 at §f[-677, 42, -4948]",
+      "description": "§7Bring §3[15 Arcane Anomalies]§7 to the Slaying Post §3[Combat Lv. 75]§7 at §f[-677, 46, -4948]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5587,7 +5592,7 @@
       ],
       "location": {
         "x": -677,
-        "y": 42,
+        "y": 46,
         "z": -4948
       }
     },
@@ -5595,7 +5600,7 @@
       "type": "miniQuest",
       "name": "Slay Wraiths \u0026 Phantasms",
       "specialInfo": "",
-      "description": "§7Bring §3[18 Unholy Spirits]§7 to the Slaying Post §3[Combat Lv. 60] §7at §f[-1392, 45, -5464]",
+      "description": "§7Bring §3[18 Unholy Spirits]§7 to the Slaying Post §3[Combat Lv. 60]§7 at §f[-1392, 49, -5464]",
       "length": "short",
       "lengthInfo": "",
       "difficulty": "easy",
@@ -5609,3938 +5614,17 @@
       ],
       "location": {
         "x": -1392,
-        "y": 45,
+        "y": 49,
         "z": -5464
       }
     }
   ],
-  "cave": [
-    {
-      "type": "cave",
-      "name": "Abyssal Shine",
-      "specialInfo": "",
-      "description": "§7In a cave dark as the depths of the ocean, shining stalks grow and attract glowing moths at §f[605, 27, -5072]§7, and...?",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 87,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 605,
-        "y": 27,
-        "z": -5072
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Ancestor Grotto",
-      "specialInfo": "",
-      "description": "§7A tiny cave of corrupted Old Timers at §f[-628, 48, -1953]",
-      "length": "short",
-      "lengthInfo": "20s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 2,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40 XP",
-        "1 Unidentified Leggings",
-        "Various Items"
-      ],
-      "location": {
-        "x": -628,
-        "y": 48,
-        "z": -1953
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Angel Falls",
-      "specialInfo": "",
-      "description": "§7Angels taken refuge inside the islands at §f[1026, 109, -4697]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 97,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1026,
-        "y": 109,
-        "z": -4697
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Aquaculture Aquifer",
-      "specialInfo": "",
-      "description": "§7A strange old Aquifer has fertile soil and has been converted into a subterranean farm at §f[-1930, 83, -3325]§7 Yet a famine lies at its deepest core",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1930,
-        "y": 83,
-        "z": -3325
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Avos Animation Totem",
-      "specialInfo": "Boss Cave",
-      "description": "§7Beware what lives at §f[-1759, 37, -2450]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 98,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1759,
-        "y": 37,
-        "z": -2450
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Azer Athenaeum",
-      "specialInfo": "",
-      "description": "§7The Azer who wish to learn and wish to fight make home at §f[1511, 48, -5176]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 92,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1511,
-        "y": 48,
-        "z": -5176
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Azurite Island",
-      "specialInfo": "",
-      "description": "§7A crazed crystal and the madman who took it lies at §f[953, 141, -4761]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 94,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 953,
-        "y": 141,
-        "z": -4761
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Bandit Groundbreaking",
-      "specialInfo": "",
-      "description": "§7The bandits menacing the Cinfras County are trying to dig a new hideout at §f[-287, 45, -5552]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 75,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "150000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -287,
-        "y": 45,
-        "z": -5552
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Basalt Basin",
-      "specialInfo": "",
-      "description": "§7Dying embers of what appears to be a volcano past its prime lies at §f[-557, 31, -460]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -557,
-        "y": 31,
-        "z": -460
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Bird Sanctuary",
-      "specialInfo": "",
-      "description": "§7A flock of birds gathered in a cave around §f[-928, 30, -410] §7Some say a strange person lives deep in the cave among them",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 60,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -928,
-        "y": 30,
-        "z": -410
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Blaze Springs",
-      "specialInfo": "",
-      "description": "§7Beware the blaze infestation at the lava spring near §f[830, 45, -5350]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 830,
-        "y": 45,
-        "z": -5350
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Blazing Oasis",
-      "specialInfo": "",
-      "description": "§7Even in an awe inspiring subterranean ecosystem, corruption makes its Oasis §f[924, 75, -1348]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 30,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "4500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 924,
-        "y": 75,
-        "z": -1348
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Blind Burrow",
-      "specialInfo": "",
-      "description": "§7Senses gone missing in a twisted evolution have resulted in the burrows at §f[1393, 163, -1055]",
-      "length": "medium",
-      "lengthInfo": "1m40s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1393,
-        "y": 163,
-        "z": -1055
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Boar Burrow",
-      "specialInfo": "",
-      "description": "§7A massive colony of boars have burrowed their way into a cavern at §f[-227, 56, -2097]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 23,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -227,
-        "y": 56,
-        "z": -2097
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Bovine Bedrock",
-      "specialInfo": "Tower",
-      "description": "§7Bedrock has shot out the ground, and some strange bovine creatures have made it home at §f[-608, 48, -4904]",
-      "length": "medium",
-      "lengthInfo": "1m45s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 71,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "60000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -608,
-        "y": 48,
-        "z": -4904
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Breaking Ice",
-      "specialInfo": "",
-      "description": "§7A cave covered in thin ice and full of rocky creatures around §f[-134, 73, -797]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 46,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "12000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -134,
-        "y": 73,
-        "z": -797
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Broodmother\u0027s Bestiary",
-      "specialInfo": "Tower",
-      "description": "§7Harpies have taken to the mountaintops with a path beginning near §f[645, 91, -5328]",
-      "length": "long",
-      "lengthInfo": "1m50s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 645,
-        "y": 91,
-        "z": -5328
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Builder-Bot Central",
-      "specialInfo": "",
-      "description": "§7Builder bots have gone past their programming and are making strange masonry structures inside a cave at §f[-1674, 52, -3060]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1674,
-        "y": 52,
-        "z": -3060
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Burning Bog",
-      "specialInfo": "Cave Complex",
-      "description": "§7Kandrekk warlocks have claimed a bog hidden behind ancient Gylia Ruins at §f[-411, 37, -5205]§7, and seek to watch the world burn",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 79,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "260000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -411,
-        "y": 37,
-        "z": -5205
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Burning Delve",
-      "specialInfo": "",
-      "description": "§7Elephelks unfortunate enough to take a dip into the nearby open lava lake inhabit this cave at §f[346, 34, -4606]§7 as well as some nastier creatures",
-      "length": "medium",
-      "lengthInfo": "1m15s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 87,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "250000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 346,
-        "y": 34,
-        "z": -4606
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Caged Creatures",
-      "specialInfo": "",
-      "description": "§7The caretakers have become the pets. Rules are upturned in a twisted spectacle, hidden away at §f[1134, 135, -1121]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1134,
-        "y": 135,
-        "z": -1121
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cannibal Walkways",
-      "specialInfo": "",
-      "description": "§7On the walkways and platforms of a cliffside at §f[-956, 43, -525] §7Cannibals have made their camp",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 71,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -956,
-        "y": 43,
-        "z": -525
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Captain\u0027s Quarters",
-      "specialInfo": "",
-      "description": "§7Find a drunken pirate captain in his underground hideout around §f[561, 38, -2085]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 19,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1450 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 561,
-        "y": 38,
-        "z": -2085
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Carnadile Den",
-      "specialInfo": "",
-      "description": "§7The Carnadiles make their den around §f[-725, 64, -731]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 53,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -725,
-        "y": 64,
-        "z": -731
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cave Springs",
-      "specialInfo": "",
-      "description": "§7A cave spring full of life around §f[310, 59, -1851]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 17,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 310,
-        "y": 59,
-        "z": -1851
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cave of Doom",
-      "specialInfo": "",
-      "description": "§7Enter the cave of demons at §f[1405, 28, -5067]§7 and wait for a great monster to appear.",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1405,
-        "y": 28,
-        "z": -5067
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cave of the Seasons",
-      "specialInfo": "Cave Complex",
-      "description": "§7Light and the seasons have taken physical form under a strange tree growing out of §f[-864, 51, -6131]",
-      "length": "long",
-      "lengthInfo": "5m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 82,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -864,
-        "y": 51,
-        "z": -6131
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Chiseler\u0027s Cavern",
-      "specialInfo": "",
-      "description": "§7Long abandoned, constructed gargoyles in various states of decay guard a cave near §f[622, 31, -4695]",
-      "length": "medium",
-      "lengthInfo": "1m5s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 89,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 622,
-        "y": 31,
-        "z": -4695
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Corkus Quarry",
-      "specialInfo": "",
-      "description": "§7LAZERS and explosives are being used by the bots to dig out a massive quarry at §f[-1365, 93, -2736]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1365,
-        "y": 93,
-        "z": -2736
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Corrupt Time Warp",
-      "specialInfo": "",
-      "description": "§7Enter an old Time Valley temple and experience the effects of the corrupted crystal inside §f[-332, 68, -1301]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 22,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1200 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -332,
-        "y": 68,
-        "z": -1301
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Corrupted Passageway",
-      "specialInfo": "Boss Cave",
-      "description": "§7A Passageway with a Mysterious door §f[-497, 67, -1629]§7 Perhaps a key could be found on some nearby structure.",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 9,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "340 XP",
-        "64 Emeralds",
-        "1 Unidentified Helmet",
-        "Various Items"
-      ],
-      "location": {
-        "x": -497,
-        "y": 67,
-        "z": -1629
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Corruption Mines",
-      "specialInfo": "",
-      "description": "§7A mine from old times completely consumed by The Roots of Corruption §f[170, 70, -1187]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 28,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "2500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 170,
-        "y": 70,
-        "z": -1187
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Crab Fighters",
-      "specialInfo": "",
-      "description": "§7A chaotic underground crab fighting ring at §f[-799, 37, -1965]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 6,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "150 XP",
-        "64 Emeralds",
-        "Various Items"
-      ],
-      "location": {
-        "x": -799,
-        "y": 37,
-        "z": -1965
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cryovern Covert",
-      "specialInfo": "",
-      "description": "§7A covert of Cryovern lies up in the Frozen Heights around §f[1526, 67, -5427]",
-      "length": "long",
-      "lengthInfo": "2m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 94,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1526,
-        "y": 67,
-        "z": -5427
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Crypt Excavation",
-      "specialInfo": "",
-      "description": "§7Miners on an excavation have been corrupted! Find loot left behind around §f[-32, 69, -1432]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 6,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "350 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -32,
-        "y": 69,
-        "z": -1432
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Crystal Caverns",
-      "specialInfo": "",
-      "description": "§7Rumors say that the deepest parts of this cavern are covered in a purple crystal §f[1120, 75, -2177]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 30,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1300 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1120,
-        "y": 75,
-        "z": -2177
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Crystalline Polynya",
-      "specialInfo": "",
-      "description": "§7Sea ice and crystalline creatures converge in a cavern below the waves at §f[1203, 36, -2937]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 39,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "7000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1203,
-        "y": 36,
-        "z": -2937
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cultists Passage",
-      "specialInfo": "",
-      "description": "§7Cultists have taken refuge in a small passageway around §f[-1261, 45, -4460]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 63,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1261,
-        "y": 45,
-        "z": -4460
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cyclonic Spirit Trap",
-      "specialInfo": "",
-      "description": "§7Spirits trapped by the canyon walls are funneled by the wind to caves such as the one at §f[600, 38, -5266]§7, and...?",
-      "length": "medium",
-      "lengthInfo": "1m15s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 83,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 600,
-        "y": 38,
-        "z": -5266
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Cyclopes\u0027 Shrine",
-      "specialInfo": "",
-      "description": "§7Cyclopes fight trolls to claim an old shrine at §f[51, 46, -4456]",
-      "length": "medium",
-      "lengthInfo": "55s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 88,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 51,
-        "y": 46,
-        "z": -4456
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Demolition Derby",
-      "specialInfo": "",
-      "description": "§7Hobgoblins seem interested in exploding an obstruction near §f[590, 29, -4625]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 590,
-        "y": 29,
-        "z": -4625
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Derelict Mine",
-      "specialInfo": "",
-      "description": "§7A mine boarded up to keep dangers inside at §f[-627, 69, -1760]",
-      "length": "short",
-      "lengthInfo": "40s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 6,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "75 XP",
-        "64 Emeralds",
-        "Various Items"
-      ],
-      "location": {
-        "x": -627,
-        "y": 69,
-        "z": -1760
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Deserter\u0027s Refuge",
-      "specialInfo": "",
-      "description": "§7A group of Gavellian army deserters are hiding in a cave underneath the path around §f[499, 79, -5299]",
-      "length": "medium",
-      "lengthInfo": "1m5s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 499,
-        "y": 79,
-        "z": -5299
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Detlas Salt Mine",
-      "specialInfo": "",
-      "description": "§7The Detlas salt mine has been overrun with the corrupt at §f[21, 63, -1767]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 10,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "340 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 21,
-        "y": 63,
-        "z": -1767
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Dragon Delta",
-      "specialInfo": "",
-      "description": "§7Feed the great dragon statue, and find what remains inside the ancient beast at §f[1259, 47, -5343]",
-      "length": "long",
-      "lengthInfo": "4m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 93,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1259,
-        "y": 47,
-        "z": -5343
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Dragonkin Nest",
-      "specialInfo": "",
-      "description": "§7Poachers say, if you gather the scales from the Draconic nests and bring them to the large nest at §f[1464, 172, -5529]§7 you can find great reward.",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1464,
-        "y": 172,
-        "z": -5529
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Drone\u0027s Retreat",
-      "specialInfo": "",
-      "description": "§7The only creatures to ever have escaped the Qira Hive\u0027s strict watch hide away in the mountains at §f[234, 123, -5422]",
-      "length": "medium",
-      "lengthInfo": "1m15s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 80,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 234,
-        "y": 123,
-        "z": -5422
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Dullahan Gardens",
-      "specialInfo": "",
-      "description": "§7Deep in the castle gardens you\u0027ll find many a dangerous creature around §f[-1132, 82, -5684]",
-      "length": "long",
-      "lengthInfo": "2m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 65,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1132,
-        "y": 82,
-        "z": -5684
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Dust Bowl",
-      "specialInfo": "",
-      "description": "§7Dust storms and creatures have taken life in this mine at §f[1003, 73, -1704]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 30,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1003,
-        "y": 73,
-        "z": -1704
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Earth Eaters",
-      "specialInfo": "",
-      "description": "§7The earth is being eaten away by strange creatures around §f[-1388, 45, -4981]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 68,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1388,
-        "y": 45,
-        "z": -4981
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Elemental Hollow",
-      "specialInfo": "",
-      "description": "§7Chaotic conglomerations of elemental energies appear and threaten Gelibord at §f[-1110, 47, -5290]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 66,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1110,
-        "y": 47,
-        "z": -5290
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Emerald Knives Hideout",
-      "specialInfo": "",
-      "description": "§7The Emerald Knives are hoarding their ill-gotten gains in an old mine at §f[1338, 79, -1705]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 35,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1300 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1338,
-        "y": 79,
-        "z": -1705
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Eyeball Gauntlet",
-      "specialInfo": "",
-      "description": "§7Nothing remains unseen within §f[1088, 137, -345]§7. All is lain bare",
-      "length": "long",
-      "lengthInfo": "4m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1088,
-        "y": 137,
-        "z": -345
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Fallen Passage",
-      "specialInfo": "",
-      "description": "§7A bug infested passage has fallen on itself around §f[1301, 86, -2144]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 32,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1200 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1301,
-        "y": 86,
-        "z": -2144
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Fire \u0026 Water",
-      "specialInfo": "",
-      "description": "§7A corrupted cave of opposing elements located at §f[-502, 71, -1722]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 7,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "90 XP",
-        "1 ❉ Water Powder I",
-        "1 ✹ Fire Powder I",
-        "Various Items"
-      ],
-      "location": {
-        "x": -502,
-        "y": 71,
-        "z": -1722
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Fire Swamp",
-      "specialInfo": "",
-      "description": "§7A swampy cliffside cave has been seen alight at §f[-2098, 59, -5117]",
-      "length": "long",
-      "lengthInfo": "2m20s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 57,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -2098,
-        "y": 59,
-        "z": -5117
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Flesh Mesh",
-      "specialInfo": "",
-      "description": "§7The tunnels beneath Kander\u0027s viscera pits at §f[-751, 38, -5503]§7 are dark, disgusting, dangerous, and full to bursting of discarded belongings",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -751,
-        "y": 38,
-        "z": -5503
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Forgotten Excavation",
-      "specialInfo": "Boss Cave",
-      "description": "§7A lost Golem stands guard over the spoils of an excavation at §f[987, 67, -4977]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 987,
-        "y": 67,
-        "z": -4977
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Fortress Catacombs",
-      "specialInfo": "",
-      "description": "§7Some say if you crawl through the catacombs at §f[-1336, 45, -5079] §7you can find great rewards.",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 64,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "45000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1336,
-        "y": 45,
-        "z": -5079
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Frog Hole",
-      "specialInfo": "",
-      "description": "§7Frogs have gathered together and made a huge den at §f[-1756, 57, -5133]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 50,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1756,
-        "y": 57,
-        "z": -5133
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Fungas Log",
-      "specialInfo": "",
-      "description": "§7An old dead tree stump is overran with evolved fungi at §f[-142, 74, -1679]",
-      "length": "short",
-      "lengthInfo": "40s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 5,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "150 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -142,
-        "y": 74,
-        "z": -1679
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Gator Range",
-      "specialInfo": "",
-      "description": "§7Alligator people live in the little ponds of a cave around §f[1306, 31, -1452]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 37,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1200 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1306,
-        "y": 31,
-        "z": -1452
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Geodesic",
-      "specialInfo": "Cave Complex",
-      "description": "§7Fall into a great cavern at §f[-1369, 121, -3060]",
-      "length": "long",
-      "lengthInfo": "5m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1369,
-        "y": 121,
-        "z": -3060
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Gold Rush",
-      "specialInfo": "",
-      "description": "§7An old gold mine at §f[1440, 33, -1369]§7 Maybe the man outside will let you in",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 38,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1440,
-        "y": 33,
-        "z": -1369
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Gorgon Gorge",
-      "specialInfo": "",
-      "description": "§7Cut into the mountains at §f[715, 47, -5495]§7 you will find the watery home of these terrifying creatures.",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 80,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 715,
-        "y": 47,
-        "z": -5495
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Guardians Cove",
-      "specialInfo": "",
-      "description": "§7Those who wish nature harm beware of it\u0027s guardians that reside at §f[129, 45, -5565]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "250000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 129,
-        "y": 45,
-        "z": -5565
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Half Moon Island",
-      "specialInfo": "Island",
-      "description": "§7Explore the strange Half Moon Island and find all its treasure and danger at §f[1085, 37, -2566]",
-      "length": "long",
-      "lengthInfo": "5m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 37,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "20000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1085,
-        "y": 37,
-        "z": -2566
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Haze Cave",
-      "specialInfo": "",
-      "description": "§7Bile will run from your mouth like a waterfall, and your lungs crystallize. Do not breathe in §f[948, 93, -1049]",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 948,
-        "y": 93,
-        "z": -1049
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Headless Hollow",
-      "specialInfo": "",
-      "description": "§7Most do not even speak of what lurks inside that creepy hollow at §f[-22, 76, -297]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 45,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -22,
-        "y": 76,
-        "z": -297
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Hex Keep Gateway",
-      "specialInfo": "Cave Complex",
-      "description": "§7The entrance to a great subterranean keep; many more dangers await deeper in the keep §f[-433, 66, -1691]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 7,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1500 XP",
-        "192 Emeralds",
-        "Various Items"
-      ],
-      "location": {
-        "x": -433,
-        "y": 66,
-        "z": -1691
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Hill Hovel",
-      "specialInfo": "",
-      "description": "§7A little hovel in the hills fallen to corruption at §f[241, 70, -1559]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 11,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "340 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 241,
-        "y": 70,
-        "z": -1559
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Holehold Orc Camp",
-      "specialInfo": "",
-      "description": "§7The Orcish couriers and recordkeepers gather in Holehold §f[-1767, 48, -4778]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 45,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1767,
-        "y": 48,
-        "z": -4778
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Ice Doors",
-      "specialInfo": "",
-      "description": "§7A frosted over doorway; find a key and be given one of two challenges to face at §f[-118, 70, -923]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 41,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "12000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -118,
-        "y": 70,
-        "z": -923
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Jade Well",
-      "specialInfo": "",
-      "description": "§7At §f[-799, 43, -608]§7 lies a temple well that goes deep into the jade laden ground",
-      "length": "medium",
-      "lengthInfo": "1m40s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 60,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -799,
-        "y": 43,
-        "z": -608
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Jungle Fetish Camp",
-      "specialInfo": "",
-      "description": "§7Hordes of Fetishes are stopping Iboju medicine makers from getting their herbs at §f[-698, 33, -607]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 64,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "19000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -698,
-        "y": 33,
-        "z": -607
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Jungle Horrors",
-      "specialInfo": "",
-      "description": "§7Some bloody horrors have taken place in a cave around §f[-609, 108, -579]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 54,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -609,
-        "y": 108,
-        "z": -579
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Jungle Labyrinth",
-      "specialInfo": "",
-      "description": "§7An ancient labyrinth full of the undead and ancient residents of Iboju §f[-667, 59, -926]",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 66,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "19000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -667,
-        "y": 59,
-        "z": -926
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Junk Pit",
-      "specialInfo": "",
-      "description": "§7Old bots and scrap have been creeping around inside the junk pit at §f[-1782, 64, -2569]",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1782,
-        "y": 64,
-        "z": -2569
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Kander Crypt",
-      "specialInfo": "",
-      "description": "§7Some say the Old Lexdale crypts at §f[-406, 47, -5444]§7 are cursed with the spirits killed in the siege, others say it contains treasures deep inside",
-      "length": "long",
-      "lengthInfo": "2m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -406,
-        "y": 47,
-        "z": -5444
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lake Pit",
-      "specialInfo": "",
-      "description": "§7A lake island sinkhole full of the corrupt and undead at §f[477, 68, -1226]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 24,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 477,
-        "y": 68,
-        "z": -1226
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lamprophis Lair",
-      "specialInfo": "",
-      "description": "§7Earth and stone have taken a slithery form at §f[1054, 46, -4961]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1054,
-        "y": 46,
-        "z": -4961
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Ledant Hill",
-      "specialInfo": "",
-      "description": "§7Explore through the Ledant Hill and find riches at §f[-1222, 74, -4856]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "100000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1222,
-        "y": 74,
-        "z": -4856
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lily Pad Parkour",
-      "specialInfo": "",
-      "description": "§7Jump through a cave full of giant lily pads at §f[-1834, 57, -5172]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 55,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1834,
-        "y": 57,
-        "z": -5172
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lion\u0027s Lair",
-      "specialInfo": "",
-      "description": "§7Extremely dangerous lion poachers have overtaken a mining operation at §f[768, 93, -2211]§7.",
-      "length": "long",
-      "lengthInfo": "4m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 30,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "2000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 768,
-        "y": 93,
-        "z": -2211
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Loot Symposium",
-      "specialInfo": "",
-      "description": "§7Everything is false and nothing is real. Find the place at §f[775, 153, -950]§7 and see for yourself",
-      "length": "long",
-      "lengthInfo": "1m50s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 775,
-        "y": 153,
-        "z": -950
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lovers\u0027 Cavern",
-      "specialInfo": "",
-      "description": "§7Where lovers go to be at rest for eternity §f[394, 44, -1990]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 20,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "444 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 394,
-        "y": 44,
-        "z": -1990
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lower Abandoned Mines",
-      "specialInfo": "",
-      "description": "§7The deeper depths of the Abandoned Mines §f[769, 27, -1280]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 22,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1200 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 769,
-        "y": 27,
-        "z": -1280
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Lush Grotto",
-      "specialInfo": "",
-      "description": "§7Below the waters at §f[719, 36, -2853]§7 a lush cave awaits, but the creatures within do not want to be disturbed",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 28,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "3400 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 719,
-        "y": 36,
-        "z": -2853
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Maddening Mud",
-      "specialInfo": "",
-      "description": "§7A muddy cave at §f[-1544, 48, -5337]§7 turns some who enter mad",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 53,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1544,
-        "y": 48,
-        "z": -5337
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Mesquis Tower",
-      "specialInfo": "Tower",
-      "description": "§7Great danger lies atop this tower at §f[-785, 58, -5036]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -785,
-        "y": 58,
-        "z": -5036
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Mossy Grotto",
-      "specialInfo": "",
-      "description": "§7An elegant little Grotto full of life and danger at §f[-449, 67, -1394]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 16,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -449,
-        "y": 67,
-        "z": -1394
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Muddy Cavern",
-      "specialInfo": "",
-      "description": "§7A mud hole full of the undead has unearthed around §f[112, 48, -1945]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 20,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "444 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 112,
-        "y": 48,
-        "z": -1945
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Mycolite Mountain",
-      "specialInfo": "",
-      "description": "§7Fungus, Mycelium, Mycolite, have infested the mountainside at §f[1015, 103, -4358]",
-      "length": "long",
-      "lengthInfo": "1m50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 96,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1015,
-        "y": 103,
-        "z": -4358
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Mystifying Stump",
-      "specialInfo": "Cave Complex",
-      "description": "§7Find your way though the stump at §f[-754, 53, -5299]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -754,
-        "y": 53,
-        "z": -5299
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Naga Dugout",
-      "specialInfo": "Boss Cave",
-      "description": "§7A sneaky Naga Commander has made camp in a dugout at §f[-2025, 59, -5081]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 58,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -2025,
-        "y": 59,
-        "z": -5081
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Nest \u0026 Bones",
-      "specialInfo": "",
-      "description": "§7Climb the bones around §f[1467, 46, -5559]§7 and search for the hidden entrance to the Fire Wyverns\u0027 nest.",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1467,
-        "y": 46,
-        "z": -5559
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Nymph Towers",
-      "specialInfo": "Rock Towers",
-      "description": "§7Climb the earthen towers and find what treasure the nymphs have at §f[-1052, 46, -4768]",
-      "length": "medium",
-      "lengthInfo": "1m45s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 69,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1052,
-        "y": 46,
-        "z": -4768
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Old Growth Rot",
-      "specialInfo": "",
-      "description": "§7A tree stands rotten to the core; only kept standing by the corrupt\u0027s wrought §f[-265, 71, -1529]",
-      "length": "short",
-      "lengthInfo": "30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 7,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -265,
-        "y": 71,
-        "z": -1529
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Orc Cove",
-      "specialInfo": "",
-      "description": "§7Ridiculous rumors state an orc camp full of ruin-seekers lies beneath a lake §f[-1827, 53, -4899]",
-      "length": "short",
-      "lengthInfo": "40s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 46,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1827,
-        "y": 53,
-        "z": -4899
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Overgrown Rubble",
-      "specialInfo": "",
-      "description": "§7An overgrown cave has gone to rubble and caved in! Trek through the rubble and find what\u0027s inside at §f[742, 87, -4890]",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 96,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 742,
-        "y": 87,
-        "z": -4890
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Ovine Spire",
-      "specialInfo": "Tower",
-      "description": "§7A cabal of fluffy jumbucks have established a Guard Tower at §f[778, 81, -4721]",
-      "length": "long",
-      "lengthInfo": "2m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 96,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 778,
-        "y": 81,
-        "z": -4721
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Pigman Outpost",
-      "specialInfo": "",
-      "description": "§7Pigmen are cooking up something outside Ragni at §f[-622, 69, -1570]",
-      "length": "short",
-      "lengthInfo": "30s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 1,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "30 XP",
-        "13 Emeralds",
-        "1 Blank",
-        "Various Items"
-      ],
-      "location": {
-        "x": -622,
-        "y": 69,
-        "z": -1570
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Pirate Hold",
-      "specialInfo": "",
-      "description": "§7Pirates crashed in the cliffside! Find their treasure at §f[489, 39, -2067]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 18,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1450 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 489,
-        "y": 39,
-        "z": -2067
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Pirate Lattice",
-      "specialInfo": "",
-      "description": "§7Pirates have reprogrammed some machines to do their dirty work and defend their treacherous lattice work hideout at §f[-1394, 66, -2393]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1394,
-        "y": 66,
-        "z": -2393
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Pirate Sloop",
-      "specialInfo": "Dock",
-      "description": "§7Find the pirates dock to their hideout at §f[-1341, 35, -2229]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1341,
-        "y": 35,
-        "z": -2229
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Plasmatic Gouge",
-      "specialInfo": "",
-      "description": "§7Fiery creatures hot enough to bloat and warp solid rock lie in a searing cavern at §f[411, 40, -5166]§7, and...?",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 89,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 411,
-        "y": 40,
-        "z": -5166
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Quicksand Carvers\u0027 Den",
-      "specialInfo": "",
-      "description": "§7The Quicksand Carvers have risen from the dead alongside monsters around §f[974, 64, -2109]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 34,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 974,
-        "y": 64,
-        "z": -2109
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Raging Survivor",
-      "specialInfo": "",
-      "description": "§7In an old shipwreck full of frostbitten bandits at §f[-287, 26, -555]§7, one lone survivor burns on guarding the remaining stolen wealth.",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 45,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -287,
-        "y": 26,
-        "z": -555
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Raging Tower",
-      "specialInfo": "Tower",
-      "description": "§7An old tower overtaken by fiery corrupt with a powerful being looming overtop at §f[144, 68, -1680]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 10,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "210 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 144,
-        "y": 68,
-        "z": -1680
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Raiders\u0027 Hideout",
-      "specialInfo": "",
-      "description": "§7The last hideout of some lost Raiders taken by corruption long ago §f[-252, 34, -291]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 44,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -252,
-        "y": 34,
-        "z": -291
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Raiders\u0027 Rockhill",
-      "specialInfo": "",
-      "description": "§7Watch your step around the Rockhill at §f[-111, 37, -4621]§7, Bandits and Raiders are known to lurk around and keep their stolen treasure inside",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 73,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "150000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -111,
-        "y": 37,
-        "z": -4621
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Recluse Nest",
-      "specialInfo": "",
-      "description": "§7Those that enter the nest at §f[-755, 46, -4830]§7 often end up a part of it.",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 70,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -755,
-        "y": 46,
-        "z": -4830
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Rocky Peril",
-      "specialInfo": "",
-      "description": "§7Rock Hunters are looking for something valuable near the cave at §f[330, 67, -4916]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 330,
-        "y": 67,
-        "z": -4916
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Root Slingers\u0027 Rut",
-      "specialInfo": "",
-      "description": "§7The roots themselves attack those who swim into the rut at §f[-177, 34, -4864]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 75,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "100000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -177,
-        "y": 34,
-        "z": -4864
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Roots of Infestation",
-      "specialInfo": "",
-      "description": "§7There is a deep rooted cave infested with spiders at §f[-209, 70, -1570]",
-      "length": "short",
-      "lengthInfo": "40s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 7,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "250 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -209,
-        "y": 70,
-        "z": -1570
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Rotten Altar",
-      "specialInfo": "",
-      "description": "§7A horde of the corrupt have gathered around this altar at §f[-570, 68, -612]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 54,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -570,
-        "y": 68,
-        "z": -612
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Runaway Fleris Cranny",
-      "specialInfo": "",
-      "description": "§7Escaped Flerisi have heated everything in this cave into a frenetic boil at §f[323, 68, -4633]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 88,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 323,
-        "y": 68,
-        "z": -4633
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Scarred Ingress",
-      "specialInfo": "",
-      "description": "§7Geological phenomena have been spotted crawling out of the earth at §f[1264, 148, -4647]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 93,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1264,
-        "y": 148,
-        "z": -4647
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Scorched Earth",
-      "specialInfo": "",
-      "description": "§7A deep cave full of scorched creatures and earth lies at §f[1603, 154, -5069]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 94,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1603,
-        "y": 154,
-        "z": -5069
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Secret Mine",
-      "specialInfo": "",
-      "description": "§7Some unscrupulous individuals have taken to an illegal mining operation around §f[-1490, 48, -4990]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 46,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1490,
-        "y": 48,
-        "z": -4990
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Seismic Bore Hole",
-      "specialInfo": "",
-      "description": "§7Earth-boring insects chew away the canyon stone at §f[635, 54, -4716]§7, and...?",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "250000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 635,
-        "y": 54,
-        "z": -4716
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Sewer Herps",
-      "specialInfo": "",
-      "description": "§7A collection of dangerous reptiles and monsters can be found in an ancient sewer around §f[-1983, 65, -5234]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 57,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1983,
-        "y": 65,
-        "z": -5234
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Shadow Altar",
-      "specialInfo": "Boss Cave",
-      "description": "§7Fill the altar and fight what lives inside at §f[1271, 95, -5427]",
-      "length": "medium",
-      "lengthInfo": "1m40s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 92,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1271,
-        "y": 95,
-        "z": -5427
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Shadow Spears Refuge",
-      "specialInfo": "",
-      "description": "§7The remains of the Shadow Spear Bandits are hiding around §f[1339, 33, -1552]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 35,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1339,
-        "y": 33,
-        "z": -1552
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Shock Shrine",
-      "specialInfo": "",
-      "description": "§7Elves worshiping thunder can be found at §f[-647, 50, -4419]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 75,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "100000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -647,
-        "y": 50,
-        "z": -4419
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Shroom Sleeper Dugout",
-      "specialInfo": "",
-      "description": "§7Nothing but Shroom Sleepers lie at §f[-551, 45, -4689]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 71,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "70000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -551,
-        "y": 45,
-        "z": -4689
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Sink Hole",
-      "specialInfo": "",
-      "description": "§7Some eerie houses have sunken into the mud at §f[-1512, 50, -5243]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 55,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1512,
-        "y": 50,
-        "z": -5243
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Skien\u0027s Prison Block",
-      "specialInfo": "",
-      "description": "§7The undead prison warden of Skien\u0027s Island has locked up a peculiar new prisoner at §f[405, 9, -3468]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 55,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "20000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 405,
-        "y": 9,
-        "z": -3468
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Sky Shroom",
-      "specialInfo": "Boss Cave",
-      "description": "§7A strange shroom grows up around §f[1199, 108, -4289]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1199,
-        "y": 108,
-        "z": -4289
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Sol Hive",
-      "specialInfo": "",
-      "description": "§7Ground dwelling bees have made a hive around §f[-2203, 93, -4929]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 46,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "10000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -2203,
-        "y": 93,
-        "z": -4929
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Spiteful Crossing",
-      "specialInfo": "",
-      "description": "§7Those risen from the pit out of spite and envy remain trapped at §f[854, 81, -668]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 854,
-        "y": 81,
-        "z": -668
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Spore Spiral",
-      "specialInfo": "",
-      "description": "§7A Spiral like cave full of fungus at §f[670, 71, -1617]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 12,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 670,
-        "y": 71,
-        "z": -1617
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Statue Opening",
-      "specialInfo": "",
-      "description": "§7The statues are moving. The statues are moving. The statues are moving. The statues must stop moving. The statues are at §f[826, 79, -429]§7. The statues are moving.",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 826,
-        "y": 79,
-        "z": -429
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Steamworks",
-      "specialInfo": "",
-      "description": "§7Try not to get lost or overheat inside the vents and pipeworks at §f[-1471, 63, -2376]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1471,
-        "y": 63,
-        "z": -2376
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Submerged Coal Mine",
-      "specialInfo": "",
-      "description": "§7A fragile sheet of ice covers an old coal mine at §f[-120, 30, -294]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 45,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -120,
-        "y": 30,
-        "z": -294
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Subterranean Mire",
-      "specialInfo": "",
-      "description": "§7Mud and sludge have come to life in a cave around §f[-809, 23, -448]",
-      "length": "short",
-      "lengthInfo": "40s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 60,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -809,
-        "y": 23,
-        "z": -448
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Sunken Ship",
-      "specialInfo": "",
-      "description": "§7Off Nemract\u0027s coast lies treasure sunken under a shipwreck at §f[215, 34, -2410]§7, too far underwater to reach without special equipment",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 18,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 215,
-        "y": 34,
-        "z": -2410
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Swamp Hill",
-      "specialInfo": "",
-      "description": "§7Enter a hollowed out swampy hill at §f[-2059, 58, -5241]",
-      "length": "short",
-      "lengthInfo": "40s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 50,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "40000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -2059,
-        "y": 58,
-        "z": -5241
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Temple Entrance",
-      "specialInfo": "",
-      "description": "§7This temple marks the entrance of an infested jungle cavern at §f[-675, 32, -306]",
-      "length": "medium",
-      "lengthInfo": "1m20s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 68,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -675,
-        "y": 32,
-        "z": -306
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Termite Mounds",
-      "specialInfo": "Cave Complex",
-      "description": "§7Termite Mounds across the Savannah! Find one of the entrances to their maze of tunnels and treasures at §f[727, 76, -1707]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 24,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "5000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 727,
-        "y": 76,
-        "z": -1707
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Alcazar",
-      "specialInfo": "",
-      "description": "§7A massive fortification built into the mountains of Time Valley located at §f[-499, 76, -1024]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 27,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -499,
-        "y": 76,
-        "z": -1024
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Donjon",
-      "specialInfo": "",
-      "description": "§7The Donjon has been cursed by a malicious totem, transforming its denizens at §f[900, 97, -4408]§7. It has been locked tight",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 95,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 900,
-        "y": 97,
-        "z": -4408
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Gwanari",
-      "specialInfo": "",
-      "description": "§7Nothing escapes its maw. Never enter. Do not go near §f[983, 75, -470]§7 or you will be nothing but gristle and bone",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 983,
-        "y": 75,
-        "z": -470
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Heartwood",
-      "specialInfo": "",
-      "description": "§7At §f[-625, 66, -289]§7 you will find heartwood and roots of a tree that once was",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 69,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -625,
-        "y": 66,
-        "z": -289
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Lantern Keeper\u0027s Abode",
-      "specialInfo": "",
-      "description": "§7It burns itself alive to let others fade to ashes. The flames will burn you at §f[1285, 103, -1060]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1285,
-        "y": 103,
-        "z": -1060
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Place Coalesced",
-      "specialInfo": "",
-      "description": "§7Wanderers out of Lutho are taken and changed at §f[879, 79, -803]§7, where sickness and toxicity are coalesced",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 879,
-        "y": 79,
-        "z": -803
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Place Condensed",
-      "specialInfo": "",
-      "description": "§7Condensed and warped into new forms, new matter threatens the east of Lutho §f[1038, 84, -692]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1038,
-        "y": 84,
-        "z": -692
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Place Conglomerated",
-      "specialInfo": "",
-      "description": "§7In a place stolen by nothingness, life is conglomerated, mutated, and sent to grow over the stolen world from §f[1313, 144, -1048]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 100,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1313,
-        "y": 144,
-        "z": -1048
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Sacrificial Altar",
-      "specialInfo": "Boss Cave",
-      "description": "§7Dark Cultists have gathered around an Altar in a cliffside cave around §f[-298, 38, -969]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 22,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "500 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -298,
-        "y": 38,
-        "z": -969
-      }
-    },
-    {
-      "type": "cave",
-      "name": "The Warehouse",
-      "specialInfo": "Cave Complex",
-      "description": "§7Bots manage a complex warehouse deep in the ground at §f[-1847, 41, -2641]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 90,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "400000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -1847,
-        "y": 41,
-        "z": -2641
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Thunder Grub Nest",
-      "specialInfo": "",
-      "description": "§7A nest of thunderous grubs can be found around §f[-618, 62, -728]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 53,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -618,
-        "y": 62,
-        "z": -728
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Tidepool Terrace",
-      "specialInfo": "",
-      "description": "§7Some trouble is brewing in some underground tidepools at §f[-512, 35, -2015]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 4,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "25 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -512,
-        "y": 35,
-        "z": -2015
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Time Valley Aquifer",
-      "specialInfo": "",
-      "description": "§7Some dangerous fauna can be found in this aquifer at §f[-377, 74, -1167]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 26,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "600 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -377,
-        "y": 74,
-        "z": -1167
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Treasure Tomb",
-      "specialInfo": "",
-      "description": "§7A hidden tomb with a spiny guard around §f[1030, 68, -2169]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 30,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1030,
-        "y": 68,
-        "z": -2169
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Tree of Light",
-      "specialInfo": "",
-      "description": "§7Many mysteries and creatures make their home in the great tree at §f[-893, 54, -6217]",
-      "length": "long",
-      "lengthInfo": "1m50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 77,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "250000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -893,
-        "y": 54,
-        "z": -6217
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Troll Burrows",
-      "specialInfo": "",
-      "description": "§7A large gathering of trolls are peacefully minding their business a bit too close to Thesead at §f[858, 80, -5198]",
-      "length": "medium",
-      "lengthInfo": "50s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 80,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "250000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 858,
-        "y": 80,
-        "z": -5198
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Troll Tower",
-      "specialInfo": "",
-      "description": "§7Climb the elusive troll tower at §f[1106, 85, -2870]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 30,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "2000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1106,
-        "y": 85,
-        "z": -2870
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Trunk Garrison",
-      "specialInfo": "",
-      "description": "§7A garrison of the corrupt has taken refuge through a tree trunk at §f[-560, 79, -959]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 51,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "14000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -560,
-        "y": 79,
-        "z": -959
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Visceral Remnant",
-      "specialInfo": "",
-      "description": "§7Bodies subjected to grisly stitching and experimentation rejuvenated and rise at §f[-997, 45, -5559]§7, where no one should enter",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 74,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -997,
-        "y": 45,
-        "z": -5559
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Volcanus Pit",
-      "specialInfo": "",
-      "description": "§7Enter the depths of the Volcanic Isles at §f[-830, 40, -3794]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 58,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "15000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -830,
-        "y": 40,
-        "z": -3794
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Voltaic Crag",
-      "specialInfo": "",
-      "description": "§7Thunder elementals have carved a thunderbolt-shaped crag in the cliff at §f[630, 44, -4945]§7, and...?",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 81,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 630,
-        "y": 44,
-        "z": -4945
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Vortex Complex",
-      "specialInfo": "Cave Complex",
-      "description": "§7Enter this deep and confusing complex and find what treasure lies within §f[-182, 71, -1210]",
-      "length": "long",
-      "lengthInfo": "3m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 22,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -182,
-        "y": 71,
-        "z": -1210
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Watery Waterfall",
-      "specialInfo": "",
-      "description": "§7Animated water beings have formed in an odd cave nearby §f[536, 30, -5363]",
-      "length": "medium",
-      "lengthInfo": "1m30s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 85,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "300000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 536,
-        "y": 30,
-        "z": -5363
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Wave Cult Temple",
-      "specialInfo": "",
-      "description": "§7Warlocks leading a sinister following can be found at §f[-251, 36, -2725]§7, preaching their tidal glory",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 32,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -251,
-        "y": 36,
-        "z": -2725
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Weird Wilds",
-      "specialInfo": "",
-      "description": "§7As fate ordained, particularly strong Weirds have conglomerated at §f[-967, 65, -4353]§7 for purposes incomprehensible.",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 72,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "150000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -967,
-        "y": 65,
-        "z": -4353
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Weirding Ring",
-      "specialInfo": "Tower",
-      "description": "§7Instead of fae spirits, Weirds have congealed in a ring of giant climbable mushrooms at §f[-498, 41, -5293]",
-      "length": "long",
-      "lengthInfo": "2m",
-      "difficulty": "hard",
-      "requirements": {
-        "level": 75,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "50000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": -498,
-        "y": 41,
-        "z": -5293
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Willow Crypt",
-      "specialInfo": "",
-      "description": "§7An ancient Crypt with hidden dangers can be found at §f[591, 81, -1866]",
-      "length": "medium",
-      "lengthInfo": "1m",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 16,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "1050 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 591,
-        "y": 81,
-        "z": -1866
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Windwalker Temple",
-      "specialInfo": "",
-      "description": "§7A large tree has grown out of the hillside at §f[1358, 121, -4745]",
-      "length": "short",
-      "lengthInfo": "45s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 96,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "700000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 1358,
-        "y": 121,
-        "z": -4745
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Winery Infestation",
-      "specialInfo": "",
-      "description": "§7An old wine cellar infested with the corrupt at §f[282, 70, -1392]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "medium",
-      "requirements": {
-        "level": 11,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "340 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 282,
-        "y": 70,
-        "z": -1392
-      }
-    },
-    {
-      "type": "cave",
-      "name": "Wolf Den",
-      "specialInfo": "",
-      "description": "§7The home of the wolves all around the frozen area of Nesaak, found around §f[175, 72, -715]",
-      "length": "medium",
-      "lengthInfo": "1m10s",
-      "difficulty": "easy",
-      "requirements": {
-        "level": 43,
-        "professionLevels": {},
-        "quests": []
-      },
-      "rewards": [
-        "10000 XP",
-        "Various Items"
-      ],
-      "location": {
-        "x": 175,
-        "y": 72,
-        "z": -715
-      }
-    }
-  ],
+  "worldEvent": [],
   "secretDiscovery": [
     {
       "type": "secretDiscovery",
       "name": "A Deathly Warning",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9558,7 +5642,7 @@
     {
       "type": "secretDiscovery",
       "name": "A Dividing Force",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9576,7 +5660,7 @@
     {
       "type": "secretDiscovery",
       "name": "A Hero\u0027s Origin",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9594,7 +5678,7 @@
     {
       "type": "secretDiscovery",
       "name": "A Monument of Hope",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§aSilent Expanse",
       "description": "§7Just as the darkness infiltrated Gavel, the Light was able to protect the physical bodies of the miners in Lutho by erecting this Monolith.",
       "length": null,
       "lengthInfo": "",
@@ -9612,7 +5696,7 @@
     {
       "type": "secretDiscovery",
       "name": "A Wynnic Excavation",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§eSilent Expanse",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9630,7 +5714,7 @@
     {
       "type": "secretDiscovery",
       "name": "Abandoned Excavations",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§eLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9648,7 +5732,7 @@
     {
       "type": "secretDiscovery",
       "name": "Ahmsord\u0027s Origins",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9666,7 +5750,7 @@
     {
       "type": "secretDiscovery",
       "name": "At the Edge of Decay",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§eLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9684,7 +5768,7 @@
     {
       "type": "secretDiscovery",
       "name": "Bak\u0027al\u0027s Destruction 1",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9702,7 +5786,7 @@
     {
       "type": "secretDiscovery",
       "name": "Bak\u0027al\u0027s Destruction 2",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§aWynn Plains",
       "description": "§7A once great city of Akias was reduced to rubble in 347 AP (After Portal) in one of the largest attacks by Bak\u0027al ever documented. There was only one survivor.",
       "length": null,
       "lengthInfo": "",
@@ -9720,7 +5804,7 @@
     {
       "type": "secretDiscovery",
       "name": "Bak\u0027al\u0027s Destruction 3",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§aWynn Plains",
       "description": "§7Just the name of Bak\u0027al is enough to make many cower in fear. They say that wherever he appears, he will only leave death in his wake.",
       "length": null,
       "lengthInfo": "",
@@ -9738,7 +5822,7 @@
     {
       "type": "secretDiscovery",
       "name": "Beneath the Roots",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9756,7 +5840,7 @@
     {
       "type": "secretDiscovery",
       "name": "Birth of Efilim",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§eLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9774,7 +5858,7 @@
     {
       "type": "secretDiscovery",
       "name": "Boulder Breaker",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§aWynn Plains",
       "description": "§7Attacks from the portal were often so brutal, it forced people underground. Sometimes, they never made it back out.",
       "length": null,
       "lengthInfo": "",
@@ -9792,7 +5876,7 @@
     {
       "type": "secretDiscovery",
       "name": "Boulder Pit",
-      "specialInfo": "Desert",
+      "specialInfo": "§aDesert",
       "description": "§7The Emperor\u0027s 26th son was named Hashr. As he grew older, he became wrought with greed and envy of his father\u0027s power. It wasn\u0027t long before he was willing to kill.",
       "length": null,
       "lengthInfo": "",
@@ -9810,7 +5894,7 @@
     {
       "type": "secretDiscovery",
       "name": "Canyon Housing",
-      "specialInfo": "Canyon of the Lost",
+      "specialInfo": "§eCanyon of the Lost",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9828,7 +5912,7 @@
     {
       "type": "secretDiscovery",
       "name": "Chained Goliaths",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§eMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9846,7 +5930,7 @@
     {
       "type": "secretDiscovery",
       "name": "Colossal Ruins",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9864,7 +5948,7 @@
     {
       "type": "secretDiscovery",
       "name": "Cosmic Crystals",
-      "specialInfo": "Canyon of the Lost",
+      "specialInfo": "§eCanyon of the Lost",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9882,7 +5966,7 @@
     {
       "type": "secretDiscovery",
       "name": "Cracked Canyon",
-      "specialInfo": "Canyon of the Lost",
+      "specialInfo": "§eCanyon of the Lost",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9900,7 +5984,7 @@
     {
       "type": "secretDiscovery",
       "name": "Crate Crane",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§aWynn Plains",
       "description": "§7Nemract was one of the cities attacked most often. The people would hide in the gutters and sewers until it was over. However, corrupt enemies are not without intelligence, and they were quickly discovered by the enemy.",
       "length": null,
       "lengthInfo": "",
@@ -9918,7 +6002,7 @@
     {
       "type": "secretDiscovery",
       "name": "Cultural Artefact",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§eMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9936,7 +6020,7 @@
     {
       "type": "secretDiscovery",
       "name": "Decaying Mountains",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§eOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9954,7 +6038,7 @@
     {
       "type": "secretDiscovery",
       "name": "Desert Royal Residence",
-      "specialInfo": "Desert",
+      "specialInfo": "§cDesert",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9972,7 +6056,7 @@
     {
       "type": "secretDiscovery",
       "name": "Desolate Temples",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -9990,7 +6074,7 @@
     {
       "type": "secretDiscovery",
       "name": "Empty Vaults",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§eOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10008,7 +6092,7 @@
     {
       "type": "secretDiscovery",
       "name": "Explorer\u0027s Corruption Study",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10026,7 +6110,7 @@
     {
       "type": "secretDiscovery",
       "name": "Far Above the Clouds",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10044,7 +6128,7 @@
     {
       "type": "secretDiscovery",
       "name": "Far From the Roots",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10062,7 +6146,7 @@
     {
       "type": "secretDiscovery",
       "name": "Fate of the Olm",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§eSilent Expanse",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10080,7 +6164,7 @@
     {
       "type": "secretDiscovery",
       "name": "Fracture in Reality",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§eLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10098,7 +6182,7 @@
     {
       "type": "secretDiscovery",
       "name": "Frozen Cave Hideout",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10116,7 +6200,7 @@
     {
       "type": "secretDiscovery",
       "name": "Gavel Excavation",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§eGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10134,7 +6218,7 @@
     {
       "type": "secretDiscovery",
       "name": "Gylia Watch Library",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§eGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10152,7 +6236,7 @@
     {
       "type": "secretDiscovery",
       "name": "Gylia\u0027s Cataclysm",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§cGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10170,7 +6254,7 @@
     {
       "type": "secretDiscovery",
       "name": "Hallowed Ground",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10188,7 +6272,7 @@
     {
       "type": "secretDiscovery",
       "name": "Harmless Worms",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§eOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10206,7 +6290,7 @@
     {
       "type": "secretDiscovery",
       "name": "Headless, Not Homeless",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10224,7 +6308,7 @@
     {
       "type": "secretDiscovery",
       "name": "Historical Maltic",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§aWynn Plains",
       "description": "§7Maltic was the first settlement ever made by the arriving villagers. The alliance between Villagers and Humans would go on to save the province.",
       "length": null,
       "lengthInfo": "",
@@ -10242,7 +6326,7 @@
     {
       "type": "secretDiscovery",
       "name": "Light Mushrooms",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§eLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10260,7 +6344,7 @@
     {
       "type": "secretDiscovery",
       "name": "Llevigar\u0027s Last Hope",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§cLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10278,7 +6362,7 @@
     {
       "type": "secretDiscovery",
       "name": "Llevigar\u0027s Secret Library",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§eLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10296,7 +6380,7 @@
     {
       "type": "secretDiscovery",
       "name": "Loot of the Lost",
-      "specialInfo": "Canyon of the Lost",
+      "specialInfo": "§eCanyon of the Lost",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10314,7 +6398,7 @@
     {
       "type": "secretDiscovery",
       "name": "Lost Avos City",
-      "specialInfo": "Corkus",
+      "specialInfo": "§aCorkus",
       "description": "§7The history of the Avos has remained largely unknown, but this monument of Avos ancestry might hold the ancient secrets that historians have been looking for.",
       "length": null,
       "lengthInfo": "",
@@ -10332,7 +6416,7 @@
     {
       "type": "secretDiscovery",
       "name": "Lost Farmers",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§eOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10350,7 +6434,7 @@
     {
       "type": "secretDiscovery",
       "name": "Lusuco\u0027s Secret Library",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§aNesaak Tundra",
       "description": "§7This old library has been slumbering beneath Lusuco for years. It tells the story of the legendary Twain children.",
       "length": null,
       "lengthInfo": "",
@@ -10368,7 +6452,7 @@
     {
       "type": "secretDiscovery",
       "name": "Maex Black Market",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§eMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10386,7 +6470,7 @@
     {
       "type": "secretDiscovery",
       "name": "Mark of the Meteors",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§eGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10404,7 +6488,7 @@
     {
       "type": "secretDiscovery",
       "name": "Messengers From Beyond",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§eLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10422,7 +6506,7 @@
     {
       "type": "secretDiscovery",
       "name": "Mining Cessation",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§eSilent Expanse",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10440,7 +6524,7 @@
     {
       "type": "secretDiscovery",
       "name": "Mining Operation",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10458,7 +6542,7 @@
     {
       "type": "secretDiscovery",
       "name": "Ne du Valeos du Ellach",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§cLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10476,7 +6560,7 @@
     {
       "type": "secretDiscovery",
       "name": "Necklace Chamber",
-      "specialInfo": "Corkus",
+      "specialInfo": "§eCorkus",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10494,7 +6578,7 @@
     {
       "type": "secretDiscovery",
       "name": "Nilrem\u0027s Sealed Letter",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10512,7 +6596,7 @@
     {
       "type": "secretDiscovery",
       "name": "Otherworldly Occurrence",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§eSilent Expanse",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10530,7 +6614,7 @@
     {
       "type": "secretDiscovery",
       "name": "Otherworldly Origins",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10548,7 +6632,7 @@
     {
       "type": "secretDiscovery",
       "name": "Parasite Cocoon",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10566,7 +6650,7 @@
     {
       "type": "secretDiscovery",
       "name": "Pottery Wheel",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10584,7 +6668,7 @@
     {
       "type": "secretDiscovery",
       "name": "Quicksand",
-      "specialInfo": "Desert",
+      "specialInfo": "§eDesert",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10602,7 +6686,7 @@
     {
       "type": "secretDiscovery",
       "name": "Ragni\u0027s Secret Library",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10620,7 +6704,7 @@
     {
       "type": "secretDiscovery",
       "name": "Relos\u0027 Secret Library",
-      "specialInfo": "Corkus",
+      "specialInfo": "§eCorkus",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10638,7 +6722,7 @@
     {
       "type": "secretDiscovery",
       "name": "Ruins of Detlas",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§aWynn Plains",
       "description": "§7The modern city of Detlas was built with the help of villagers after their arrival in Wynn. But these ruins might hold the secrets of what lied before...",
       "length": null,
       "lengthInfo": "",
@@ -10656,7 +6740,7 @@
     {
       "type": "secretDiscovery",
       "name": "Rulers of the Skies",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10674,7 +6758,7 @@
     {
       "type": "secretDiscovery",
       "name": "Rymek Thief",
-      "specialInfo": "Desert",
+      "specialInfo": "§eDesert",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10692,7 +6776,7 @@
     {
       "type": "secretDiscovery",
       "name": "Sealed Away",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§eLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10710,7 +6794,7 @@
     {
       "type": "secretDiscovery",
       "name": "Sealed in Ice",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§eMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10728,7 +6812,7 @@
     {
       "type": "secretDiscovery",
       "name": "Shadowy Dealings",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§eOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10746,7 +6830,7 @@
     {
       "type": "secretDiscovery",
       "name": "Shrouded Lives",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§eOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10764,7 +6848,7 @@
     {
       "type": "secretDiscovery",
       "name": "Silent Expanse\u0027s Secret",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§cSilent Expanse",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10782,7 +6866,7 @@
     {
       "type": "secretDiscovery",
       "name": "Somewhere In Between",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10800,7 +6884,7 @@
     {
       "type": "secretDiscovery",
       "name": "Space Between Realities",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§aSilent Expanse",
       "description": "§7Between Realms of physicality and influence lies the vast nothingness of the void. Some islands have broken from the lands and drift in this space, seeking purpose.",
       "length": null,
       "lengthInfo": "",
@@ -10818,7 +6902,7 @@
     {
       "type": "secretDiscovery",
       "name": "Spider Ruins",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§eLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10836,7 +6920,7 @@
     {
       "type": "secretDiscovery",
       "name": "Subterranean Creation",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§eMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10854,7 +6938,7 @@
     {
       "type": "secretDiscovery",
       "name": "Summoner\u0027s Fate",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10872,7 +6956,7 @@
     {
       "type": "secretDiscovery",
       "name": "Teachings of Old",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§eLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10890,7 +6974,7 @@
     {
       "type": "secretDiscovery",
       "name": "Temple Ruin",
-      "specialInfo": "Desert",
+      "specialInfo": "§eDesert",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10908,7 +6992,7 @@
     {
       "type": "secretDiscovery",
       "name": "Temple of Light",
-      "specialInfo": "Light Forest",
+      "specialInfo": "§eLight Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10926,7 +7010,7 @@
     {
       "type": "secretDiscovery",
       "name": "Temple of Swords",
-      "specialInfo": "Desert",
+      "specialInfo": "§eDesert",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10944,7 +7028,7 @@
     {
       "type": "secretDiscovery",
       "name": "Thanos Armory",
-      "specialInfo": "Canyon of the Lost",
+      "specialInfo": "§eCanyon of the Lost",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10962,7 +7046,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Ancient Ones",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§eGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10980,7 +7064,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Bane of Gavel",
-      "specialInfo": "Olux Swamp",
+      "specialInfo": "§cOlux Swamp",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -10998,7 +7082,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Broken Protector",
-      "specialInfo": "Canyon of the Lost",
+      "specialInfo": "§cCanyon of the Lost",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11016,7 +7100,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Doguns\u0027 Defeat",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§cMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11034,7 +7118,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Fallen Protector",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§cSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11052,7 +7136,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Final Moments",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§eSilent Expanse",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11070,7 +7154,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Forest has Eyes",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§aSilent Expanse",
       "description": "§7For every miner in Lutho that lost contact with their inner self, two eyes grow from the trees.",
       "length": null,
       "lengthInfo": "",
@@ -11088,7 +7172,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Grand Archive",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§eGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11106,7 +7190,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Great Barrier",
-      "specialInfo": "Gylia Plains",
+      "specialInfo": "§eGylia Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11124,7 +7208,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Heart of the Decay",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§cDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11142,7 +7226,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Lone Telescope",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11160,7 +7244,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Lonely Abyss",
-      "specialInfo": "Sky Islands",
+      "specialInfo": "§eSky Islands",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11178,7 +7262,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Talor Crypt",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11196,7 +7280,7 @@
     {
       "type": "secretDiscovery",
       "name": "The Twains\u0027 Downfall",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§cNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11214,7 +7298,7 @@
     {
       "type": "secretDiscovery",
       "name": "Timeless Ruin",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11232,7 +7316,7 @@
     {
       "type": "secretDiscovery",
       "name": "Tomb of the Founders",
-      "specialInfo": "Molten Heights",
+      "specialInfo": "§eMolten Heights",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11250,7 +7334,7 @@
     {
       "type": "secretDiscovery",
       "name": "Torn in Twain",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11268,7 +7352,7 @@
     {
       "type": "secretDiscovery",
       "name": "Totem Pole",
-      "specialInfo": "Desert",
+      "specialInfo": "§eDesert",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11286,7 +7370,7 @@
     {
       "type": "secretDiscovery",
       "name": "Toxic Bounce",
-      "specialInfo": "Silent Expanse",
+      "specialInfo": "§aSilent Expanse",
       "description": "§7The land influenced by Dern can manifest in many ways, here a monster and landscape merged to become one sentient creature.",
       "length": null,
       "lengthInfo": "",
@@ -11304,7 +7388,7 @@
     {
       "type": "secretDiscovery",
       "name": "Unstable Experiments",
-      "specialInfo": "Llevigar Plains",
+      "specialInfo": "§eLlevigar Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11322,7 +7406,7 @@
     {
       "type": "secretDiscovery",
       "name": "Watchmen",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11340,7 +7424,7 @@
     {
       "type": "secretDiscovery",
       "name": "Water of the Past",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§eWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11358,7 +7442,7 @@
     {
       "type": "secretDiscovery",
       "name": "Ways of the Wicked",
-      "specialInfo": "Dark Forest",
+      "specialInfo": "§eDark Forest",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11376,7 +7460,7 @@
     {
       "type": "secretDiscovery",
       "name": "Wolf Temple",
-      "specialInfo": "Nesaak Tundra",
+      "specialInfo": "§eNesaak Tundra",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -11394,7 +7478,7 @@
     {
       "type": "secretDiscovery",
       "name": "Wrecking Ball",
-      "specialInfo": "Desert",
+      "specialInfo": "§aDesert",
       "description": "§7When the Creden Tibus discovered the Emperor\u0027s Sceptre in an ancient, hidden temple, they decided to hide it closer to home. After many generations, they grew paranoid, and moved it once more.",
       "length": null,
       "lengthInfo": "",
@@ -11412,7 +7496,7 @@
     {
       "type": "secretDiscovery",
       "name": "Wynn Plains Monument",
-      "specialInfo": "Wynn Plains",
+      "specialInfo": "§cWynn Plains",
       "description": "",
       "length": null,
       "lengthInfo": "",
@@ -13755,7 +9839,7 @@
       "type": "worldDiscovery",
       "name": "The Great Bridge",
       "specialInfo": "",
-      "description": "§7RUN.",
+      "description": "§7While it is unknown when it was built, this bridge serves as one of the only ways to access the Jungle. Usually the bustling of travelers and salesmen alike echoes throughout its halls...",
       "length": null,
       "lengthInfo": "",
       "difficulty": null,
@@ -20360,6 +16444,3962 @@
       "location": null
     }
   ],
+  "cave": [
+    {
+      "type": "cave",
+      "name": "Abyssal Shine",
+      "specialInfo": "",
+      "description": "§7In a cave dark as the depths of the ocean, shining stalks grow and attract glowing moths at §f[605, 27, -5072]§7, and...?",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 87,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 605,
+        "y": 27,
+        "z": -5072
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Ancestor Grotto",
+      "specialInfo": "",
+      "description": "§7A tiny cave of corrupted Old Timers at §f[-628, 48, -1953]",
+      "length": "short",
+      "lengthInfo": "20s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 2,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40 XP",
+        "1 §dUnidentified Leggings",
+        "Various Items"
+      ],
+      "location": {
+        "x": -628,
+        "y": 48,
+        "z": -1953
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Angel Falls",
+      "specialInfo": "",
+      "description": "§7Angels taken refuge inside the islands at §f[1026, 109, -4697]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 97,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1026,
+        "y": 109,
+        "z": -4697
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Aquaculture Aquifer",
+      "specialInfo": "",
+      "description": "§7A strange old Aquifer has fertile soil and has been converted into a subterranean farm at §f[-1930, 83, -3325]§7 Yet a famine lies at its deepest core",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1930,
+        "y": 83,
+        "z": -3325
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Avos Animation Totem",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7Beware what lives at §f[-1759, 37, -2450]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 98,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1759,
+        "y": 37,
+        "z": -2450
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Azer Athenaeum",
+      "specialInfo": "",
+      "description": "§7The Azer who wish to learn and wish to fight make home at §f[1511, 48, -5176]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 92,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1511,
+        "y": 48,
+        "z": -5176
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Azurite Island",
+      "specialInfo": "",
+      "description": "§7A crazed crystal and the madman who took it lies at §f[953, 141, -4761]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 94,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 953,
+        "y": 141,
+        "z": -4761
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Bandit Groundbreaking",
+      "specialInfo": "",
+      "description": "§7The bandits menacing the Cinfras County are trying to dig a new hideout at §f[-287, 45, -5552]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 75,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "150000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -287,
+        "y": 45,
+        "z": -5552
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Basalt Basin",
+      "specialInfo": "",
+      "description": "§7Dying embers of what appears to be a volcano past its prime lies at §f[-557, 31, -460]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -557,
+        "y": 31,
+        "z": -460
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Bird Sanctuary",
+      "specialInfo": "",
+      "description": "§7A flock of birds gathered in a cave around §f[-928, 30, -410] §7Some say a strange person lives deep in the cave among them",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 60,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -928,
+        "y": 30,
+        "z": -410
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Blaze Springs",
+      "specialInfo": "",
+      "description": "§7Beware the blaze infestation at the lava spring near §f[830, 45, -5350]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 830,
+        "y": 45,
+        "z": -5350
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Blazing Oasis",
+      "specialInfo": "",
+      "description": "§7Even in an awe inspiring subterranean ecosystem, corruption makes its Oasis §f[924, 75, -1348]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 30,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "4500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 924,
+        "y": 75,
+        "z": -1348
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Blind Burrow",
+      "specialInfo": "",
+      "description": "§7Senses gone missing in a twisted evolution have resulted in the burrows at §f[1393, 163, -1055]",
+      "length": "medium",
+      "lengthInfo": "1m40s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1393,
+        "y": 163,
+        "z": -1055
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Boar Burrow",
+      "specialInfo": "",
+      "description": "§7A massive colony of boars have burrowed their way into a cavern at §f[-227, 56, -2097]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 23,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -227,
+        "y": 56,
+        "z": -2097
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Bovine Bedrock",
+      "specialInfo": "§eTower",
+      "description": "§7Bedrock has shot out the ground, and some strange bovine creatures have made it home at §f[-608, 48, -4904]",
+      "length": "medium",
+      "lengthInfo": "1m45s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 71,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "60000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -608,
+        "y": 48,
+        "z": -4904
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Breaking Ice",
+      "specialInfo": "",
+      "description": "§7A cave covered in thin ice and full of rocky creatures around §f[-134, 73, -797]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 46,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "12000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -134,
+        "y": 73,
+        "z": -797
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Broodmother\u0027s Bestiary",
+      "specialInfo": "§eTower",
+      "description": "§7Harpies have taken to the mountaintops with a path beginning near §f[645, 91, -5328]",
+      "length": "long",
+      "lengthInfo": "1m50s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 645,
+        "y": 91,
+        "z": -5328
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Builder-Bot Central",
+      "specialInfo": "",
+      "description": "§7Builder bots have gone past their programming and are making strange masonry structures inside a cave at §f[-1674, 52, -3060]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1674,
+        "y": 52,
+        "z": -3060
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Burning Bog",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Kandrekk warlocks have claimed a bog hidden behind ancient Gylia Ruins at §f[-411, 37, -5205]§7, and seek to watch the world burn",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 79,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "260000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -411,
+        "y": 37,
+        "z": -5205
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Burning Delve",
+      "specialInfo": "",
+      "description": "§7Elephelks unfortunate enough to take a dip into the nearby open lava lake inhabit this cave at §f[346, 34, -4606]§7 as well as some nastier creatures",
+      "length": "medium",
+      "lengthInfo": "1m15s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 87,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "250000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 346,
+        "y": 34,
+        "z": -4606
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Caged Creatures",
+      "specialInfo": "",
+      "description": "§7The caretakers have become the pets. Rules are upturned in a twisted spectacle, hidden away at §f[1134, 135, -1121]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1134,
+        "y": 135,
+        "z": -1121
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Captain\u0027s Quarters",
+      "specialInfo": "",
+      "description": "§7Find a drunken pirate captain in his underground hideout around §f[561, 38, -2085]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 19,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1450 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 561,
+        "y": 38,
+        "z": -2085
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Carnadile Den",
+      "specialInfo": "",
+      "description": "§7The Carnadiles make their den around §f[-725, 64, -731]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 53,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -725,
+        "y": 64,
+        "z": -731
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cave Springs",
+      "specialInfo": "",
+      "description": "§7A cave spring full of life around §f[310, 59, -1851]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 17,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 310,
+        "y": 59,
+        "z": -1851
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cave of Doom",
+      "specialInfo": "",
+      "description": "§7Enter the cave of demons at §f[1405, 28, -5067]§7 and wait for a great monster to appear.",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1405,
+        "y": 28,
+        "z": -5067
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cave of the Seasons",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Light and the seasons have taken physical form under a strange tree growing out of §f[-864, 51, -6131]",
+      "length": "long",
+      "lengthInfo": "5m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 82,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -864,
+        "y": 51,
+        "z": -6131
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Chiseler\u0027s Cavern",
+      "specialInfo": "",
+      "description": "§7Long abandoned, constructed gargoyles in various states of decay guard a cave near §f[622, 31, -4695]",
+      "length": "medium",
+      "lengthInfo": "1m5s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 89,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 622,
+        "y": 31,
+        "z": -4695
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Corkus Quarry",
+      "specialInfo": "",
+      "description": "§7LAZERS and explosives are being used by the bots to dig out a massive quarry at §f[-1365, 93, -2736]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1365,
+        "y": 93,
+        "z": -2736
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Corrupt Time Warp",
+      "specialInfo": "",
+      "description": "§7Enter an old Time Valley temple and experience the effects of the corrupted crystal inside §f[-332, 68, -1301]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 22,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1200 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -332,
+        "y": 68,
+        "z": -1301
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Corrupted Passageway",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7A Passageway with a Mysterious door §f[-497, 67, -1629]§7 Perhaps a key could be found on some nearby structure.",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 9,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "340 XP",
+        "64 Emeralds",
+        "1 §bUnidentified Helmet",
+        "Various Items"
+      ],
+      "location": {
+        "x": -497,
+        "y": 67,
+        "z": -1629
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Corruption Mines",
+      "specialInfo": "",
+      "description": "§7A mine from old times completely consumed by The Roots of Corruption §f[170, 70, -1187]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 28,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "2500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 170,
+        "y": 70,
+        "z": -1187
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Crab Fighters",
+      "specialInfo": "",
+      "description": "§7A chaotic underground crab fighting ring at §f[-799, 37, -1965]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 6,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "150 XP",
+        "64 Emeralds",
+        "Various Items"
+      ],
+      "location": {
+        "x": -799,
+        "y": 37,
+        "z": -1965
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cryovern Covert",
+      "specialInfo": "",
+      "description": "§7A covert of Cryovern lies up in the Frozen Heights around §f[1526, 67, -5427]",
+      "length": "long",
+      "lengthInfo": "2m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 94,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1526,
+        "y": 67,
+        "z": -5427
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Crypt Excavation",
+      "specialInfo": "",
+      "description": "§7Miners on an excavation have been corrupted! Find loot left behind around §f[-32, 69, -1432]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 6,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "350 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -32,
+        "y": 69,
+        "z": -1432
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Crystal Caverns",
+      "specialInfo": "",
+      "description": "§7Rumors say that the deepest parts of this cavern are covered in a purple crystal §f[1120, 75, -2177]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 30,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1300 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1120,
+        "y": 75,
+        "z": -2177
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Crystalline Polynya",
+      "specialInfo": "",
+      "description": "§7Sea ice and crystalline creatures converge in a cavern below the waves at §f[1203, 36, -2937]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 39,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "7000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1203,
+        "y": 36,
+        "z": -2937
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cultists Passage",
+      "specialInfo": "",
+      "description": "§7Cultists have taken refuge in a small passageway around §f[-1261, 45, -4460]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 63,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1261,
+        "y": 45,
+        "z": -4460
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cyclonic Spirit Trap",
+      "specialInfo": "",
+      "description": "§7Spirits trapped by the canyon walls are funneled by the wind to caves such as the one at §f[600, 38, -5266]§7, and...?",
+      "length": "medium",
+      "lengthInfo": "1m15s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 83,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 600,
+        "y": 38,
+        "z": -5266
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Cyclopes\u0027 Shrine",
+      "specialInfo": "",
+      "description": "§7Cyclopes fight trolls to claim an old shrine at §f[51, 46, -4456]",
+      "length": "medium",
+      "lengthInfo": "55s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 88,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 51,
+        "y": 46,
+        "z": -4456
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Demolition Derby",
+      "specialInfo": "",
+      "description": "§7Hobgoblins seem interested in exploding an obstruction near §f[590, 29, -4625]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 590,
+        "y": 29,
+        "z": -4625
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Derelict Mine",
+      "specialInfo": "",
+      "description": "§7A mine boarded up to keep dangers inside at §f[-627, 69, -1760]",
+      "length": "short",
+      "lengthInfo": "40s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 6,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "75 XP",
+        "64 Emeralds",
+        "Various Items"
+      ],
+      "location": {
+        "x": -627,
+        "y": 69,
+        "z": -1760
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Deserter\u0027s Refuge",
+      "specialInfo": "",
+      "description": "§7A group of Gavellian army deserters are hiding in a cave underneath the path around §f[499, 79, -5299]",
+      "length": "medium",
+      "lengthInfo": "1m5s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 499,
+        "y": 79,
+        "z": -5299
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Detlas Salt Mine",
+      "specialInfo": "",
+      "description": "§7The Detlas salt mine has been overrun with the corrupt at §f[21, 63, -1767]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 10,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "340 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 21,
+        "y": 63,
+        "z": -1767
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Dragon Delta",
+      "specialInfo": "",
+      "description": "§7Feed the great dragon statue, and find what remains inside the ancient beast at §f[1259, 47, -5343]",
+      "length": "long",
+      "lengthInfo": "4m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 93,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1259,
+        "y": 47,
+        "z": -5343
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Dragonkin Nest",
+      "specialInfo": "",
+      "description": "§7Poachers say, if you gather the scales from the Draconic nests and bring them to the large nest at §f[1464, 172, -5529]§7 you can find great reward.",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1464,
+        "y": 172,
+        "z": -5529
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Drone\u0027s Retreat",
+      "specialInfo": "",
+      "description": "§7The only creatures to ever have escaped the Qira Hive\u0027s strict watch hide away in the mountains at §f[234, 123, -5422]",
+      "length": "medium",
+      "lengthInfo": "1m15s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 80,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 234,
+        "y": 123,
+        "z": -5422
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Dullahan Gardens",
+      "specialInfo": "",
+      "description": "§7Deep in the castle gardens you\u0027ll find many a dangerous creature around §f[-1132, 82, -5684]",
+      "length": "long",
+      "lengthInfo": "2m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 65,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1132,
+        "y": 82,
+        "z": -5684
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Dust Bowl",
+      "specialInfo": "",
+      "description": "§7Dust storms and creatures have taken life in this mine at §f[1003, 73, -1704]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 30,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1003,
+        "y": 73,
+        "z": -1704
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Earth Eaters",
+      "specialInfo": "",
+      "description": "§7The earth is being eaten away by strange creatures around §f[-1388, 45, -4981]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 68,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1388,
+        "y": 45,
+        "z": -4981
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Elemental Hollow",
+      "specialInfo": "",
+      "description": "§7Chaotic conglomerations of elemental energies appear and threaten Gelibord at §f[-1110, 47, -5290]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 66,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1110,
+        "y": 47,
+        "z": -5290
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Emerald Knives Hideout",
+      "specialInfo": "",
+      "description": "§7The Emerald Knives are hoarding their ill-gotten gains in an old mine at §f[1338, 79, -1705]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 35,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1300 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1338,
+        "y": 79,
+        "z": -1705
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Eyeball Gauntlet",
+      "specialInfo": "",
+      "description": "§7Nothing remains unseen within §f[1088, 137, -345]§7. All is lain bare",
+      "length": "long",
+      "lengthInfo": "4m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1088,
+        "y": 137,
+        "z": -345
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Fallen Passage",
+      "specialInfo": "",
+      "description": "§7A bug infested passage has fallen on itself around §f[1301, 86, -2144]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 32,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1200 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1301,
+        "y": 86,
+        "z": -2144
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Fallen Salient",
+      "specialInfo": "",
+      "description": "§7On the walkways and platforms of a cliffside at §f[-956, 43, -525]§7, and old camp to fend against corruption has been overrun.",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 71,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -956,
+        "y": 43,
+        "z": -525
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Fire \u0026 Water",
+      "specialInfo": "",
+      "description": "§7A corrupted cave of opposing elements located at §f[-502, 71, -1722]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 7,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "90 XP",
+        "1 ❉ Water Powder I",
+        "1 ✹ Fire Powder I",
+        "Various Items"
+      ],
+      "location": {
+        "x": -502,
+        "y": 71,
+        "z": -1722
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Fire Swamp",
+      "specialInfo": "",
+      "description": "§7A swampy cliffside cave has been seen alight at §f[-2098, 59, -5117]",
+      "length": "long",
+      "lengthInfo": "2m20s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 57,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "3 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -2098,
+        "y": 59,
+        "z": -5117
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Flesh Mesh",
+      "specialInfo": "",
+      "description": "§7The tunnels beneath Kander\u0027s viscera pits at §f[-751, 38, -5503]§7 are dark, disgusting, dangerous, and full to bursting of discarded belongings",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -751,
+        "y": 38,
+        "z": -5503
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Forgotten Excavation",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7A lost Golem stands guard over the spoils of an excavation at §f[987, 67, -4977]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 987,
+        "y": 67,
+        "z": -4977
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Fortress Catacombs",
+      "specialInfo": "",
+      "description": "§7Some say if you crawl through the catacombs at §f[-1336, 45, -5079]§7 you can find great rewards.",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 64,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "45000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1336,
+        "y": 45,
+        "z": -5079
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Frog Hole",
+      "specialInfo": "",
+      "description": "§7Frogs have gathered together and made a huge den at §f[-1756, 57, -5133]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 50,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "2 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1756,
+        "y": 57,
+        "z": -5133
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Fungas Log",
+      "specialInfo": "",
+      "description": "§7An old dead tree stump is overran with evolved fungi at §f[-142, 74, -1679]",
+      "length": "short",
+      "lengthInfo": "40s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 5,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "150 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -142,
+        "y": 74,
+        "z": -1679
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Gator Range",
+      "specialInfo": "",
+      "description": "§7Alligator people live in the little ponds of a cave around §f[1306, 31, -1452]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 37,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1200 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1306,
+        "y": 31,
+        "z": -1452
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Geodesic",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Fall into a great cavern at §f[-1369, 121, -3060]§7 and behold the crystalline formations therein.",
+      "length": "long",
+      "lengthInfo": "5m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1369,
+        "y": 121,
+        "z": -3060
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Gold Rush",
+      "specialInfo": "",
+      "description": "§7An old gold mine at §f[1440, 33, -1369]§7 Maybe the man outside will let you in",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 38,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1440,
+        "y": 33,
+        "z": -1369
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Gorgon Gorge",
+      "specialInfo": "",
+      "description": "§7Cut into the mountains at §f[715, 47, -5495]§7 you will find the watery home of these terrifying creatures.",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 80,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 715,
+        "y": 47,
+        "z": -5495
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Guardians Cove",
+      "specialInfo": "",
+      "description": "§7Those who wish nature harm beware of it\u0027s guardians that reside at §f[129, 45, -5565]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "250000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 129,
+        "y": 45,
+        "z": -5565
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Half Moon Island",
+      "specialInfo": "§eIsland",
+      "description": "§7Explore the strange Half Moon Island and find all its treasure and danger at §f[1085, 37, -2566]",
+      "length": "long",
+      "lengthInfo": "5m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 37,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "20000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1085,
+        "y": 37,
+        "z": -2566
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Haze Cave",
+      "specialInfo": "",
+      "description": "§7Bile will run from your mouth like a waterfall, and your lungs crystallize. Do not breathe in §f[948, 93, -1049]",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 948,
+        "y": 93,
+        "z": -1049
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Headless Hollow",
+      "specialInfo": "",
+      "description": "§7Most do not even speak of what lurks inside that creepy hollow at §f[-22, 76, -297]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 45,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -22,
+        "y": 76,
+        "z": -297
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Hex Keep Gateway",
+      "specialInfo": "§eCave Complex",
+      "description": "§7The entrance to a great subterranean keep; many more dangers await deeper in the keep §f[-433, 66, -1691]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 7,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1500 XP",
+        "192 Emeralds",
+        "Various Items"
+      ],
+      "location": {
+        "x": -433,
+        "y": 66,
+        "z": -1691
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Hill Hovel",
+      "specialInfo": "",
+      "description": "§7A little hovel in the hills fallen to corruption at §f[241, 70, -1559]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 11,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "340 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 241,
+        "y": 70,
+        "z": -1559
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Holehold Orc Camp",
+      "specialInfo": "",
+      "description": "§7The Orcish couriers and recordkeepers gather in Holehold §f[-1767, 48, -4778]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 45,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "1 Az Rune",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1767,
+        "y": 48,
+        "z": -4778
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Ice Doors",
+      "specialInfo": "",
+      "description": "§7A frosted over doorway; find a key and be given one of two challenges to face at §f[-118, 70, -923]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 41,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "12000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -118,
+        "y": 70,
+        "z": -923
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Jade Well",
+      "specialInfo": "",
+      "description": "§7At §f[-799, 43, -608]§7 lies a temple well that goes deep into the jade laden ground",
+      "length": "medium",
+      "lengthInfo": "1m40s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 60,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -799,
+        "y": 43,
+        "z": -608
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Jungle Fetish Camp",
+      "specialInfo": "",
+      "description": "§7Hordes of Fetishes are stopping Iboju medicine makers from getting their herbs at §f[-698, 33, -607]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 64,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "19000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -698,
+        "y": 33,
+        "z": -607
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Jungle Horrors",
+      "specialInfo": "",
+      "description": "§7Some bloody horrors have taken place in a cave around §f[-609, 108, -579]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 54,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -609,
+        "y": 108,
+        "z": -579
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Jungle Labyrinth",
+      "specialInfo": "",
+      "description": "§7An ancient labyrinth full of the undead and ancient residents of Iboju §f[-667, 59, -926]",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 66,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "19000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -667,
+        "y": 59,
+        "z": -926
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Junk Pit",
+      "specialInfo": "",
+      "description": "§7Old bots and scrap have been creeping around inside the junk pit at §f[-1782, 64, -2569]",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1782,
+        "y": 64,
+        "z": -2569
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Kander Crypt",
+      "specialInfo": "",
+      "description": "§7Some say the Old Lexdale crypts at §f[-406, 47, -5444]§7 are cursed with the spirits killed in the siege, others say it contains treasures deep inside",
+      "length": "long",
+      "lengthInfo": "2m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -406,
+        "y": 47,
+        "z": -5444
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lake Pit",
+      "specialInfo": "",
+      "description": "§7A lake island sinkhole full of the corrupt and undead at §f[477, 68, -1226]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 24,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 477,
+        "y": 68,
+        "z": -1226
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lamprophis Lair",
+      "specialInfo": "",
+      "description": "§7Earth and stone have taken a slithery form at §f[1054, 46, -4961]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1054,
+        "y": 46,
+        "z": -4961
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Ledant Hill",
+      "specialInfo": "",
+      "description": "§7Explore through the Ledant Hill and find riches at §f[-1222, 74, -4856]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "100000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1222,
+        "y": 74,
+        "z": -4856
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lily Pad Parkour",
+      "specialInfo": "",
+      "description": "§7Jump through a cave full of giant lily pads at §f[-1834, 57, -5172]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 55,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "2 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1834,
+        "y": 57,
+        "z": -5172
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lion\u0027s Lair",
+      "specialInfo": "",
+      "description": "§7Extremely dangerous lion poachers have overtaken a mining operation at §f[768, 93, -2211]§7.",
+      "length": "long",
+      "lengthInfo": "4m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 30,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "2000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 768,
+        "y": 93,
+        "z": -2211
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Loot Symposium",
+      "specialInfo": "",
+      "description": "§7Everything is false and nothing is real. Find the place at §f[775, 153, -950]§7 and see for yourself",
+      "length": "long",
+      "lengthInfo": "1m50s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 775,
+        "y": 153,
+        "z": -950
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lovers\u0027 Cavern",
+      "specialInfo": "",
+      "description": "§7Where lovers go to be at rest for eternity §f[394, 44, -1990]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 20,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "444 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 394,
+        "y": 44,
+        "z": -1990
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lower Abandoned Mines",
+      "specialInfo": "",
+      "description": "§7The deeper depths of the Abandoned Mines §f[769, 27, -1280]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 22,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1200 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 769,
+        "y": 27,
+        "z": -1280
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Lush Grotto",
+      "specialInfo": "",
+      "description": "§7Below the waters at §f[719, 36, -2853]§7 a lush cave awaits, but the creatures within do not want to be disturbed",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 28,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "3400 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 719,
+        "y": 36,
+        "z": -2853
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Maddening Mud",
+      "specialInfo": "",
+      "description": "§7A muddy cave at §f[-1544, 48, -5337]§7 turns some who enter mad",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 53,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "1 Az Rune",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1544,
+        "y": 48,
+        "z": -5337
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Mesquis Tower",
+      "specialInfo": "§eTower",
+      "description": "§7Great danger lies atop this tower at §f[-785, 58, -5036]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -785,
+        "y": 58,
+        "z": -5036
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Mossy Grotto",
+      "specialInfo": "",
+      "description": "§7An elegant little Grotto full of life and danger at §f[-449, 67, -1394]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 16,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -449,
+        "y": 67,
+        "z": -1394
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Muddy Cavern",
+      "specialInfo": "",
+      "description": "§7A mud hole full of the undead has unearthed around §f[112, 48, -1945]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 20,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "444 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 112,
+        "y": 48,
+        "z": -1945
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Mycolite Mountain",
+      "specialInfo": "",
+      "description": "§7Fungus, Mycelium, Mycolite, have infested the mountainside at §f[1015, 103, -4358]",
+      "length": "long",
+      "lengthInfo": "1m50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 96,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1015,
+        "y": 103,
+        "z": -4358
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Mystifying Stump",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Find your way though the stump at §f[-754, 53, -5299]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -754,
+        "y": 53,
+        "z": -5299
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Naga Dugout",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7A sneaky Naga Commander has made camp in a dugout at §f[-2025, 59, -5081]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 58,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "2 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -2025,
+        "y": 59,
+        "z": -5081
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Nest \u0026 Bones",
+      "specialInfo": "",
+      "description": "§7Climb the bones around §f[1467, 46, -5559]§7 and search for the hidden entrance to the Fire Wyverns\u0027 nest.",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1467,
+        "y": 46,
+        "z": -5559
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Nymph Towers",
+      "specialInfo": "§eRock Towers",
+      "description": "§7Climb the earthen towers and find what treasure the nymphs have at §f[-1052, 46, -4768]",
+      "length": "medium",
+      "lengthInfo": "1m45s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 69,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1052,
+        "y": 46,
+        "z": -4768
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Old Growth Rot",
+      "specialInfo": "",
+      "description": "§7A tree stands rotten to the core; only kept standing by the corrupt\u0027s wrought §f[-265, 71, -1529]",
+      "length": "short",
+      "lengthInfo": "30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 7,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -265,
+        "y": 71,
+        "z": -1529
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Overgrown Rubble",
+      "specialInfo": "",
+      "description": "§7An overgrown cave has gone to rubble and caved in! Trek through the rubble and find what\u0027s inside at §f[742, 87, -4890]",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 96,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 742,
+        "y": 87,
+        "z": -4890
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Ovine Spire",
+      "specialInfo": "§eTower",
+      "description": "§7A cabal of fluffy jumbucks have established a Guard Tower at §f[778, 81, -4721]",
+      "length": "long",
+      "lengthInfo": "2m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 96,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 778,
+        "y": 81,
+        "z": -4721
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Pigman Barbeque",
+      "specialInfo": "",
+      "description": "§7Pigmen are cooking up something outside Ragni at §f[-622, 69, -1570]",
+      "length": "short",
+      "lengthInfo": "30s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 1,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "30 XP",
+        "13 Emeralds",
+        "1 §eBlank",
+        "Various Items"
+      ],
+      "location": {
+        "x": -622,
+        "y": 69,
+        "z": -1570
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Pirate Hold",
+      "specialInfo": "",
+      "description": "§7Pirates crashed in the cliffside! Find their treasure at §f[489, 39, -2067]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 18,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1450 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 489,
+        "y": 39,
+        "z": -2067
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Pirate Lattice",
+      "specialInfo": "",
+      "description": "§7Pirates have reprogrammed some machines to do their dirty work and defend their treacherous lattice work hideout at §f[-1394, 66, -2393]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1394,
+        "y": 66,
+        "z": -2393
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Pirate Sloop",
+      "specialInfo": "§eDock",
+      "description": "§7Find the pirates dock to their hideout at §f[-1341, 35, -2229]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1341,
+        "y": 35,
+        "z": -2229
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Plasmatic Gouge",
+      "specialInfo": "",
+      "description": "§7Fiery creatures hot enough to bloat and warp solid rock lie in a searing cavern at §f[411, 40, -5166]§7, and...?",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 89,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 411,
+        "y": 40,
+        "z": -5166
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Quicksand Carvers\u0027 Den",
+      "specialInfo": "",
+      "description": "§7The Quicksand Carvers have risen from the dead alongside monsters around §f[974, 64, -2109]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 34,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 974,
+        "y": 64,
+        "z": -2109
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Raging Survivor",
+      "specialInfo": "",
+      "description": "§7In an old shipwreck full of frostbitten bandits at §f[-287, 26, -555]§7, one lone survivor burns on guarding the remaining stolen wealth.",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 45,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -287,
+        "y": 26,
+        "z": -555
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Raging Tower",
+      "specialInfo": "§eTower",
+      "description": "§7An old tower overtaken by fiery corrupt with a powerful being looming overtop at §f[144, 68, -1680]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 10,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "210 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 144,
+        "y": 68,
+        "z": -1680
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Raiders\u0027 Hideout",
+      "specialInfo": "",
+      "description": "§7The last hideout of some lost Raiders taken by corruption long ago §f[-252, 34, -291]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 44,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -252,
+        "y": 34,
+        "z": -291
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Raiders\u0027 Rockhill",
+      "specialInfo": "",
+      "description": "§7Watch your step around the Rockhill at §f[-111, 37, -4621]§7, Bandits and Raiders are known to lurk around and keep their stolen treasure inside",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 73,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "150000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -111,
+        "y": 37,
+        "z": -4621
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Recluse Nest",
+      "specialInfo": "",
+      "description": "§7Those that enter the nest at §f[-755, 46, -4830]§7 often end up a part of it.",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 70,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -755,
+        "y": 46,
+        "z": -4830
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Rocky Peril",
+      "specialInfo": "",
+      "description": "§7Rock Hunters are looking for something valuable near the cave at §f[330, 67, -4916]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 330,
+        "y": 67,
+        "z": -4916
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Root Slingers\u0027 Rut",
+      "specialInfo": "",
+      "description": "§7The roots themselves attack those who swim into the rut at §f[-177, 34, -4864]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 75,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "100000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -177,
+        "y": 34,
+        "z": -4864
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Roots of Infestation",
+      "specialInfo": "",
+      "description": "§7There is a deep rooted cave infested with spiders at §f[-209, 70, -1570]",
+      "length": "short",
+      "lengthInfo": "40s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 7,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "250 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -209,
+        "y": 70,
+        "z": -1570
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Rotten Altar",
+      "specialInfo": "",
+      "description": "§7A horde of the corrupt have gathered around this altar at §f[-570, 68, -612]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 54,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -570,
+        "y": 68,
+        "z": -612
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Runaway Fleris Cranny",
+      "specialInfo": "",
+      "description": "§7Escaped Flerisi have heated everything in this cave into a frenetic boil at §f[323, 68, -4633]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 88,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 323,
+        "y": 68,
+        "z": -4633
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Scarred Ingress",
+      "specialInfo": "",
+      "description": "§7Geological phenomena have been spotted crawling out of the earth at §f[1264, 148, -4647]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 93,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1264,
+        "y": 148,
+        "z": -4647
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Scorched Earth",
+      "specialInfo": "",
+      "description": "§7A deep cave full of scorched creatures and earth lies at §f[1603, 154, -5069]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 94,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1603,
+        "y": 154,
+        "z": -5069
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Secret Mine",
+      "specialInfo": "",
+      "description": "§7Some unscrupulous individuals have taken to an illegal mining operation around §f[-1490, 48, -4990]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 46,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1490,
+        "y": 48,
+        "z": -4990
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Seismic Bore Hole",
+      "specialInfo": "",
+      "description": "§7Earth-boring insects chew away the canyon stone at §f[635, 54, -4716]§7, and...?",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "250000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 635,
+        "y": 54,
+        "z": -4716
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Sewer Herps",
+      "specialInfo": "",
+      "description": "§7A collection of dangerous reptiles and monsters can be found in an ancient sewer around §f[-1983, 65, -5234]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 57,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "3 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1983,
+        "y": 65,
+        "z": -5234
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Shadow Altar",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7Fill the altar and fight what lives inside at §f[1271, 95, -5427]",
+      "length": "medium",
+      "lengthInfo": "1m40s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 92,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1271,
+        "y": 95,
+        "z": -5427
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Shadow Spears Refuge",
+      "specialInfo": "",
+      "description": "§7The remains of the Shadow Spear Bandits are hiding around §f[1339, 33, -1552]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 35,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1339,
+        "y": 33,
+        "z": -1552
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Shineridge Orc Camp",
+      "specialInfo": "§eCamp",
+      "description": "§7The Orcish traders and jewelers gather riches at Shineridge, enough to make Llevigar traders jealous §f[-1621, 47, -4664]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 45,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "20000 XP",
+        "2 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1621,
+        "y": 47,
+        "z": -4664
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Shock Shrine",
+      "specialInfo": "",
+      "description": "§7Elves worshiping thunder can be found at §f[-647, 50, -4419]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 75,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "100000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -647,
+        "y": 50,
+        "z": -4419
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Shroom Sleeper Dugout",
+      "specialInfo": "",
+      "description": "§7Nothing but Shroom Sleepers lie at §f[-551, 45, -4689]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 71,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "70000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -551,
+        "y": 45,
+        "z": -4689
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Sink Hole",
+      "specialInfo": "",
+      "description": "§7Some eerie houses have sunken into the mud at §f[-1512, 50, -5243]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 55,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "2 Az Runes",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1512,
+        "y": 50,
+        "z": -5243
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Skien\u0027s Prison Block",
+      "specialInfo": "",
+      "description": "§7The undead prison warden of Skien\u0027s Island has locked up a peculiar new prisoner at §f[405, 9, -3468]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 55,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "20000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 405,
+        "y": 9,
+        "z": -3468
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Sky Shroom",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7A strange shroom grows up around §f[1199, 108, -4289]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1199,
+        "y": 108,
+        "z": -4289
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Sol Hive",
+      "specialInfo": "",
+      "description": "§7Ground dwelling bees have made a hive around §f[-2203, 93, -4929]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 46,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "10000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -2203,
+        "y": 93,
+        "z": -4929
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Spiteful Crossing",
+      "specialInfo": "",
+      "description": "§7Those risen from the pit out of spite and envy remain trapped at §f[854, 81, -668]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 854,
+        "y": 81,
+        "z": -668
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Spore Spiral",
+      "specialInfo": "",
+      "description": "§7A Spiral like cave full of fungus at §f[670, 71, -1617]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 12,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 670,
+        "y": 71,
+        "z": -1617
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Statue Opening",
+      "specialInfo": "",
+      "description": "§7The statues are moving. The statues are moving. The statues are moving. The statues must stop moving. The statues are at §f[826, 79, -429]§7. The statues are moving.",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 826,
+        "y": 79,
+        "z": -429
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Steamworks",
+      "specialInfo": "",
+      "description": "§7Try not to get lost or overheat inside the vents and pipeworks at §f[-1471, 63, -2376]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1471,
+        "y": 63,
+        "z": -2376
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Submerged Coal Mine",
+      "specialInfo": "",
+      "description": "§7A fragile sheet of ice covers an old coal mine at §f[-120, 30, -294]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 45,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -120,
+        "y": 30,
+        "z": -294
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Subterranean Mire",
+      "specialInfo": "",
+      "description": "§7Mud and sludge have come to life in a cave around §f[-809, 23, -448]",
+      "length": "short",
+      "lengthInfo": "40s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 60,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -809,
+        "y": 23,
+        "z": -448
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Sundial Sanctum",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Enter The Sanctum at §f[1062, 73, -1726]§7 if you dare §d󐀄§bSailers",
+      "length": "long",
+      "lengthInfo": "15m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 35,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "10000 XP",
+        "1 §bUnidentified Solar",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1062,
+        "y": 73,
+        "z": -1726
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Sunken Ship",
+      "specialInfo": "",
+      "description": "§7Off Nemract\u0027s coast lies treasure sunken under a shipwreck at §f[215, 34, -2410]§7, too far underwater to reach without special equipment",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 18,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 215,
+        "y": 34,
+        "z": -2410
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Swamp Hill",
+      "specialInfo": "",
+      "description": "§7Enter a hollowed out swampy hill at §f[-2059, 58, -5241]",
+      "length": "short",
+      "lengthInfo": "40s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 50,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "40000 XP",
+        "1 Az Rune",
+        "Various Items"
+      ],
+      "location": {
+        "x": -2059,
+        "y": 58,
+        "z": -5241
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Temple Entrance",
+      "specialInfo": "",
+      "description": "§7This temple marks the entrance of an infested jungle cavern at §f[-675, 32, -306]",
+      "length": "medium",
+      "lengthInfo": "1m20s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 68,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -675,
+        "y": 32,
+        "z": -306
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Termite Mounds",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Termite Mounds across the Savannah! Find one of the entrances to their maze of tunnels and treasures at §f[727, 76, -1707]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 24,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "5000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 727,
+        "y": 76,
+        "z": -1707
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Alcazar",
+      "specialInfo": "",
+      "description": "§7A massive fortification built into the mountains of Time Valley located at §f[-499, 76, -1024]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 27,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -499,
+        "y": 76,
+        "z": -1024
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Donjon",
+      "specialInfo": "",
+      "description": "§7The Donjon has been cursed by a malicious totem, transforming its denizens at §f[900, 97, -4408]§7. It has been locked tight",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 95,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 900,
+        "y": 97,
+        "z": -4408
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Gwanari",
+      "specialInfo": "",
+      "description": "§7Nothing escapes its maw. Never enter. Do not go near §f[983, 75, -470]§7 or you will be nothing but gristle and bone",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 983,
+        "y": 75,
+        "z": -470
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Heartwood",
+      "specialInfo": "",
+      "description": "§7At §f[-625, 66, -289]§7 you will find heartwood and roots of a tree that once was",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -625,
+        "y": 66,
+        "z": -289
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Lantern Keeper\u0027s Abode",
+      "specialInfo": "",
+      "description": "§7It burns itself alive to let others fade to ashes. The flames will burn you at §f[1285, 103, -1060]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1285,
+        "y": 103,
+        "z": -1060
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Place Coalesced",
+      "specialInfo": "",
+      "description": "§7Wanderers out of Lutho are taken and changed at §f[879, 79, -803]§7, where sickness and toxicity are coalesced",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 879,
+        "y": 79,
+        "z": -803
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Place Condensed",
+      "specialInfo": "",
+      "description": "§7Condensed and warped into new forms, new matter threatens the east of Lutho §f[1038, 84, -692]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1038,
+        "y": 84,
+        "z": -692
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Place Conglomerated",
+      "specialInfo": "",
+      "description": "§7In a place stolen by nothingness, life is conglomerated, mutated, and sent to grow over the stolen world from §f[1313, 144, -1048]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 100,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1313,
+        "y": 144,
+        "z": -1048
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Sacrificial Altar",
+      "specialInfo": "§eBoss Cave",
+      "description": "§7Dark Cultists have gathered around an Altar in a cliffside cave around §f[-298, 38, -969]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 22,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "500 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -298,
+        "y": 38,
+        "z": -969
+      }
+    },
+    {
+      "type": "cave",
+      "name": "The Warehouse",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Bots manage a complex warehouse deep in the ground at §f[-1847, 41, -2641]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 90,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "400000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -1847,
+        "y": 41,
+        "z": -2641
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Thunder Grub Nest",
+      "specialInfo": "",
+      "description": "§7A nest of thunderous grubs can be found around §f[-618, 62, -728]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 53,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "14000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -618,
+        "y": 62,
+        "z": -728
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Tidepool Terrace",
+      "specialInfo": "",
+      "description": "§7Some trouble is brewing in some underground tidepools at §f[-512, 35, -2015]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 4,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "25 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -512,
+        "y": 35,
+        "z": -2015
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Time Valley Aquifer",
+      "specialInfo": "",
+      "description": "§7Some dangerous fauna can be found in this aquifer at §f[-377, 74, -1167]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 26,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "600 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -377,
+        "y": 74,
+        "z": -1167
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Treasure Tomb",
+      "specialInfo": "",
+      "description": "§7A hidden tomb with a spiny guard around §f[1030, 68, -2169]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 30,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1030,
+        "y": 68,
+        "z": -2169
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Tree of Light",
+      "specialInfo": "",
+      "description": "§7Many mysteries and creatures make their home in the great tree at §f[-893, 54, -6217]",
+      "length": "long",
+      "lengthInfo": "1m50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 77,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "250000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -893,
+        "y": 54,
+        "z": -6217
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Troll Burrows",
+      "specialInfo": "",
+      "description": "§7A large gathering of trolls are peacefully minding their business a bit too close to Thesead at §f[858, 80, -5198]",
+      "length": "medium",
+      "lengthInfo": "50s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 80,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "250000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 858,
+        "y": 80,
+        "z": -5198
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Troll Tower",
+      "specialInfo": "",
+      "description": "§7Climb the elusive troll tower at §f[1106, 85, -2870]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 30,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "2000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1106,
+        "y": 85,
+        "z": -2870
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Trunk Garrison",
+      "specialInfo": "",
+      "description": "§7A garrison of the corrupt has taken refuge through a tree trunk at §f[-560, 79, -959]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 60,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "45000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -560,
+        "y": 79,
+        "z": -959
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Visceral Remnant",
+      "specialInfo": "",
+      "description": "§7Bodies subjected to grisly stitching and experimentation rejuvenated and rise at §f[-997, 45, -5559]§7, where no one should enter",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 74,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -997,
+        "y": 45,
+        "z": -5559
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Volcanus Pit",
+      "specialInfo": "",
+      "description": "§7Enter the depths of the Volcanic Isles at §f[-830, 40, -3794]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 58,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "15000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -830,
+        "y": 40,
+        "z": -3794
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Voltaic Crag",
+      "specialInfo": "",
+      "description": "§7Thunder elementals have carved a thunderbolt-shaped crag in the cliff at §f[630, 44, -4945]§7, and...?",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 81,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 630,
+        "y": 44,
+        "z": -4945
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Vortex Complex",
+      "specialInfo": "§eCave Complex",
+      "description": "§7Enter this deep and confusing complex and find what treasure lies within §f[-182, 71, -1210]",
+      "length": "long",
+      "lengthInfo": "3m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 22,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -182,
+        "y": 71,
+        "z": -1210
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Watery Waterfall",
+      "specialInfo": "",
+      "description": "§7Animated water beings have formed in an odd cave nearby §f[536, 30, -5363]",
+      "length": "medium",
+      "lengthInfo": "1m30s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "300000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 536,
+        "y": 30,
+        "z": -5363
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Wave Cult Temple",
+      "specialInfo": "",
+      "description": "§7Warlocks leading a sinister following can be found at §f[-251, 36, -2725]§7, preaching their tidal glory",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 32,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -251,
+        "y": 36,
+        "z": -2725
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Weird Wilds",
+      "specialInfo": "",
+      "description": "§7As fate ordained, particularly strong Weirds have conglomerated at §f[-967, 65, -4353]§7 for purposes incomprehensible.",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 72,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "150000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -967,
+        "y": 65,
+        "z": -4353
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Weirding Ring",
+      "specialInfo": "§eTower",
+      "description": "§7Instead of fae spirits, Weirds have congealed in a ring of giant climbable mushrooms at §f[-498, 41, -5293]",
+      "length": "long",
+      "lengthInfo": "2m",
+      "difficulty": "hard",
+      "requirements": {
+        "level": 75,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "50000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": -498,
+        "y": 41,
+        "z": -5293
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Willow Crypt",
+      "specialInfo": "",
+      "description": "§7An ancient Crypt with hidden dangers can be found at §f[591, 81, -1866]",
+      "length": "medium",
+      "lengthInfo": "1m",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 16,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "1050 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 591,
+        "y": 81,
+        "z": -1866
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Windwalker Temple",
+      "specialInfo": "",
+      "description": "§7A large tree has grown out of the hillside at §f[1358, 121, -4745]",
+      "length": "short",
+      "lengthInfo": "45s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 96,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "700000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 1358,
+        "y": 121,
+        "z": -4745
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Winery Infestation",
+      "specialInfo": "",
+      "description": "§7An old wine cellar infested with the corrupt at §f[282, 70, -1392]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 11,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "340 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 282,
+        "y": 70,
+        "z": -1392
+      }
+    },
+    {
+      "type": "cave",
+      "name": "Wolf Den",
+      "specialInfo": "",
+      "description": "§7The home of the wolves all around the frozen area of Nesaak, found around §f[175, 72, -715]",
+      "length": "medium",
+      "lengthInfo": "1m10s",
+      "difficulty": "easy",
+      "requirements": {
+        "level": 43,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [
+        "10000 XP",
+        "Various Items"
+      ],
+      "location": {
+        "x": 175,
+        "y": 72,
+        "z": -715
+      }
+    }
+  ],
   "dungeon": [
     {
       "type": "dungeon",
@@ -20570,11 +20610,9 @@
       "lengthInfo": "",
       "difficulty": "medium",
       "requirements": {
-        "level": 9,
+        "level": 8,
         "professionLevels": {},
-        "quests": [
-          "The Sewers of Ragni"
-        ]
+        "quests": []
       },
       "rewards": [
         "820 XP",
@@ -20583,9 +20621,9 @@
         "Various Items"
       ],
       "location": {
-        "x": -922,
-        "y": 65,
-        "z": -1885
+        "x": -926,
+        "y": 62,
+        "z": -1888
       }
     },
     {
@@ -20661,11 +20699,7 @@
         "3 Galleon\u0027s Graveyard Fragments",
         "Various Items"
       ],
-      "location": {
-        "x": -587,
-        "y": 39,
-        "z": -3522
-      }
+      "location": null
     },
     {
       "type": "dungeon",
@@ -20678,9 +20712,7 @@
       "requirements": {
         "level": 45,
         "professionLevels": {},
-        "quests": [
-          "Fate of the Fallen"
-        ]
+        "quests": []
       },
       "rewards": [
         "65000 XP",
@@ -20703,11 +20735,9 @@
       "lengthInfo": "",
       "difficulty": "medium",
       "requirements": {
-        "level": 18,
+        "level": 17,
         "professionLevels": {},
-        "quests": [
-          "Arachnids\u0027 Ascent֎"
-        ]
+        "quests": []
       },
       "rewards": [
         "3500 XP",
@@ -20716,9 +20746,9 @@
         "Various Items"
       ],
       "location": {
-        "x": -282,
-        "y": 35,
-        "z": -1829
+        "x": -199,
+        "y": 53,
+        "z": -1854
       }
     },
     {
@@ -20732,9 +20762,7 @@
       "requirements": {
         "level": 36,
         "professionLevels": {},
-        "quests": [
-          "Kingdom of Sand"
-        ]
+        "quests": []
       },
       "rewards": [
         "24000 XP",
@@ -20784,9 +20812,7 @@
       "requirements": {
         "level": 54,
         "professionLevels": {},
-        "quests": [
-          "Corrupted Betrayal"
-        ]
+        "quests": []
       },
       "rewards": [
         "100000 XP",
@@ -20795,9 +20821,9 @@
         "Various Items"
       ],
       "location": {
-        "x": -635,
-        "y": 59,
-        "z": -864
+        "x": -642,
+        "y": 73,
+        "z": -854
       }
     },
     {
@@ -20809,11 +20835,9 @@
       "lengthInfo": "",
       "difficulty": "medium",
       "requirements": {
-        "level": 24,
+        "level": 23,
         "professionLevels": {},
-        "quests": [
-          "The Dark Descent"
-        ]
+        "quests": []
       },
       "rewards": [
         "7500 XP",
@@ -20833,102 +20857,104 @@
       "type": "raid",
       "name": "Nest of the Grootslangs",
       "specialInfo": "",
-      "description": "",
+      "description": "§7Homes ravaged by Decay, the subterranean Grootslangs search frantically for a better habitat. Though they harbor no ill intent, they pose a significant risk for the people of Olux, and perhaps for all of Gavel.",
       "length": "medium",
       "lengthInfo": "",
-      "difficulty": "easy",
+      "difficulty": "hard",
       "requirements": {
-        "level": 55,
+        "level": 54,
         "professionLevels": {},
-        "quests": [
-          "Realm of Light I - The Worm Holes"
-        ]
+        "quests": []
       },
       "rewards": [
-        "160000 Combat XP",
-        "Charm",
-        "Tomes",
+        "Assorted Aspects",
+        "Tomes of Combat Mastery",
+        "Tomes of Defensive Mastery",
+        "Tomes of Mysticism",
+        "Tomes of Expertise",
+        "Tomes of the Marathon",
         "Various Items"
       ],
       "location": {
         "x": -1977,
         "y": 63,
-        "z": -5614
+        "z": -5635
       }
     },
     {
       "type": "raid",
       "name": "Orphion\u0027s Nexus of Light",
       "specialInfo": "",
-      "description": "",
+      "description": "§7The source of the Decay tearing apart Gavel lies within the great Nexus at the heart of the Realm of Light. The Light itself is fading. Its embodiment is suffering. Save him.",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "hard",
       "requirements": {
-        "level": 80,
+        "level": 79,
         "professionLevels": {},
         "quests": []
       },
       "rewards": [
-        "350000 Combat XP",
-        "Charm",
-        "Tomes",
+        "Assorted Aspects",
+        "Tomes of Combat Mastery",
+        "Tomes of Expertise",
         "Various Items"
       ],
       "location": {
-        "x": -731,
+        "x": -732,
         "y": 100,
-        "z": -6411
+        "z": -6435
       }
     },
     {
       "type": "raid",
       "name": "The Canyon Colossus",
       "specialInfo": "",
-      "description": "",
+      "description": "§7In its effort to protect Gavel, the Canyon Colossus instead only endangers the province. With nobody to maintain it for centuries, it is on the verge of tearing the land asunder. It must be calmed, as soon as possible.",
       "length": "medium",
       "lengthInfo": "",
-      "difficulty": "easy",
+      "difficulty": "hard",
       "requirements": {
-        "level": 90,
+        "level": 95,
         "professionLevels": {},
         "quests": []
       },
       "rewards": [
-        "1000000 Combat XP",
-        "Charm",
-        "Tomes",
+        "Assorted Aspects",
+        "Tomes of Defensive Mastery",
+        "Tomes of Mysticism",
+        "Tomes of the Marathon",
         "Various Items"
       ],
       "location": {
-        "x": 656,
-        "y": 48,
-        "z": -4447
+        "x": 693,
+        "y": 44,
+        "z": -4448
       }
     },
     {
       "type": "raid",
       "name": "The Nameless Anomaly",
       "specialInfo": "",
-      "description": "",
+      "description": "§7Void Holes are strange... Are they natural? Or are they artificial? What makes them? What happens to the matter which they replace? A particularly large Void Hole rests within the centre of the Silent Expanse, perhaps it holds the answer to these questions...",
       "length": "medium",
       "lengthInfo": "",
       "difficulty": "hard",
       "requirements": {
-        "level": 105,
+        "level": 103,
         "professionLevels": {},
         "quests": []
       },
       "rewards": [
-        "1000000 Combat XP",
-        "Charm",
-        "Tomes",
+        "Assorted Aspects",
+        "Tomes of Combat Mastery",
+        "Tomes of Expertise",
         "Various Items"
       ],
       "location": {
-        "x": 1116,
-        "y": 84,
-        "z": -907
+        "x": 1068,
+        "y": 106,
+        "z": -824
       }
     }
   ],
@@ -21221,6 +21247,26 @@
     }
   ],
   "lootrunCamp": [
+    {
+      "type": "lootrunCamp",
+      "name": "Canyon of the Lost Excursion (South)",
+      "specialInfo": "",
+      "description": "",
+      "length": "long",
+      "lengthInfo": "",
+      "difficulty": "medium",
+      "requirements": {
+        "level": 85,
+        "professionLevels": {},
+        "quests": []
+      },
+      "rewards": [],
+      "location": {
+        "x": 578,
+        "y": 79,
+        "z": -5018
+      }
+    },
     {
       "type": "lootrunCamp",
       "name": "Molten Heights Hike",

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -90,7 +90,7 @@
   },
   {
     "id": "dataStaticCaveInfo",
-    "md5": "8d329a3c3d31d2c05cf594d2dd016609",
+    "md5": "143dd6cadb8967214da630ec3168c3bc",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Reference/caves.json"
   },
   {
@@ -105,7 +105,7 @@
   },
   {
     "id": "dataStaticCombatMapFeatures",
-    "md5": "4f08f016de175c11a5ddc899f5bf6d53",
+    "md5": "30d11707b9819c0271a661120f904369",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Reference/combat_mapfeatures.json"
   },
   {

--- a/Reference/caves.json
+++ b/Reference/caves.json
@@ -29,7 +29,7 @@
     "requirements": 2,
     "rewards": [
       "40 XP",
-      "1 Unidentified Leggings",
+      "1 §dUnidentified Leggings",
       "Various Items"
     ],
     "location": {
@@ -79,7 +79,7 @@
   {
     "type": "cave",
     "name": "Avos Animation Totem",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7Beware what lives at §f[-1759, 37, -2450]",
     "length": "long",
     "lengthInfo": "3m",
@@ -269,7 +269,7 @@
   {
     "type": "cave",
     "name": "Bovine Bedrock",
-    "specialInfo": "Tower",
+    "specialInfo": "§eTower",
     "description": "§7Bedrock has shot out the ground, and some strange bovine creatures have made it home at §f[-608, 48, -4904]",
     "length": "medium",
     "lengthInfo": "1m45s",
@@ -307,7 +307,7 @@
   {
     "type": "cave",
     "name": "Broodmother's Bestiary",
-    "specialInfo": "Tower",
+    "specialInfo": "§eTower",
     "description": "§7Harpies have taken to the mountaintops with a path beginning near §f[645, 91, -5328]",
     "length": "long",
     "lengthInfo": "1m50s",
@@ -345,7 +345,7 @@
   {
     "type": "cave",
     "name": "Burning Bog",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7Kandrekk warlocks have claimed a bog hidden behind ancient Gylia Ruins at §f[-411, 37, -5205]§7, and seek to watch the world burn",
     "length": "long",
     "lengthInfo": "2m30s",
@@ -397,25 +397,6 @@
       "x": 1134,
       "y": 135,
       "z": -1121
-    }
-  },
-  {
-    "type": "cave",
-    "name": "Cannibal Walkways",
-    "specialInfo": "",
-    "description": "§7On the walkways and platforms of a cliffside at §f[-956, 43, -525] §7Cannibals have made their camp",
-    "length": "long",
-    "lengthInfo": "2m30s",
-    "difficulty": "hard",
-    "requirements": 71,
-    "rewards": [
-      "14000 XP",
-      "Various Items"
-    ],
-    "location": {
-      "x": -956,
-      "y": 43,
-      "z": -525
     }
   },
   {
@@ -497,7 +478,7 @@
   {
     "type": "cave",
     "name": "Cave of the Seasons",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7Light and the seasons have taken physical form under a strange tree growing out of §f[-864, 51, -6131]",
     "length": "long",
     "lengthInfo": "5m",
@@ -573,7 +554,7 @@
   {
     "type": "cave",
     "name": "Corrupted Passageway",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7A Passageway with a Mysterious door §f[-497, 67, -1629]§7 Perhaps a key could be found on some nearby structure.",
     "length": "medium",
     "lengthInfo": "1m20s",
@@ -582,7 +563,7 @@
     "rewards": [
       "340 XP",
       "64 Emeralds",
-      "1 Unidentified Helmet",
+      "1 §bUnidentified Helmet",
       "Various Items"
     ],
     "location": {
@@ -1032,6 +1013,25 @@
   },
   {
     "type": "cave",
+    "name": "Fallen Salient",
+    "specialInfo": "",
+    "description": "§7On the walkways and platforms of a cliffside at §f[-956, 43, -525]§7, and old camp to fend against corruption has been overrun.",
+    "length": "long",
+    "lengthInfo": "2m30s",
+    "difficulty": "hard",
+    "requirements": 71,
+    "rewards": [
+      "14000 XP",
+      "Various Items"
+    ],
+    "location": {
+      "x": -956,
+      "y": 43,
+      "z": -525
+    }
+  },
+  {
+    "type": "cave",
     "name": "Fire & Water",
     "specialInfo": "",
     "description": "§7A corrupted cave of opposing elements located at §f[-502, 71, -1722]",
@@ -1062,6 +1062,7 @@
     "requirements": 57,
     "rewards": [
       "40000 XP",
+      "3 Az Runes",
       "Various Items"
     ],
     "location": {
@@ -1092,7 +1093,7 @@
   {
     "type": "cave",
     "name": "Forgotten Excavation",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7A lost Golem stands guard over the spoils of an excavation at §f[987, 67, -4977]",
     "length": "medium",
     "lengthInfo": "1m",
@@ -1112,7 +1113,7 @@
     "type": "cave",
     "name": "Fortress Catacombs",
     "specialInfo": "",
-    "description": "§7Some say if you crawl through the catacombs at §f[-1336, 45, -5079] §7you can find great rewards.",
+    "description": "§7Some say if you crawl through the catacombs at §f[-1336, 45, -5079]§7 you can find great rewards.",
     "length": "medium",
     "lengthInfo": "1m10s",
     "difficulty": "medium",
@@ -1138,6 +1139,7 @@
     "requirements": 50,
     "rewards": [
       "40000 XP",
+      "2 Az Runes",
       "Various Items"
     ],
     "location": {
@@ -1187,8 +1189,8 @@
   {
     "type": "cave",
     "name": "Geodesic",
-    "specialInfo": "Cave Complex",
-    "description": "§7Fall into a great cavern at §f[-1369, 121, -3060]",
+    "specialInfo": "§eCave Complex",
+    "description": "§7Fall into a great cavern at §f[-1369, 121, -3060]§7 and behold the crystalline formations therein.",
     "length": "long",
     "lengthInfo": "5m",
     "difficulty": "hard",
@@ -1263,11 +1265,11 @@
   {
     "type": "cave",
     "name": "Half Moon Island",
-    "specialInfo": "Island",
+    "specialInfo": "§eIsland",
     "description": "§7Explore the strange Half Moon Island and find all its treasure and danger at §f[1085, 37, -2566]",
     "length": "long",
     "lengthInfo": "5m",
-    "difficulty": "easy",
+    "difficulty": "hard",
     "requirements": 37,
     "rewards": [
       "20000 XP",
@@ -1320,11 +1322,11 @@
   {
     "type": "cave",
     "name": "Hex Keep Gateway",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7The entrance to a great subterranean keep; many more dangers await deeper in the keep §f[-433, 66, -1691]",
     "length": "medium",
     "lengthInfo": "1m30s",
-    "difficulty": "easy",
+    "difficulty": "hard",
     "requirements": 7,
     "rewards": [
       "1500 XP",
@@ -1367,6 +1369,7 @@
     "requirements": 45,
     "rewards": [
       "14000 XP",
+      "1 Az Rune",
       "Various Items"
     ],
     "location": {
@@ -1576,6 +1579,7 @@
     "requirements": 55,
     "rewards": [
       "40000 XP",
+      "2 Az Runes",
       "Various Items"
     ],
     "location": {
@@ -1690,6 +1694,7 @@
     "requirements": 53,
     "rewards": [
       "40000 XP",
+      "1 Az Rune",
       "Various Items"
     ],
     "location": {
@@ -1701,7 +1706,7 @@
   {
     "type": "cave",
     "name": "Mesquis Tower",
-    "specialInfo": "Tower",
+    "specialInfo": "§eTower",
     "description": "§7Great danger lies atop this tower at §f[-785, 58, -5036]",
     "length": "medium",
     "lengthInfo": "1m30s",
@@ -1777,7 +1782,7 @@
   {
     "type": "cave",
     "name": "Mystifying Stump",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7Find your way though the stump at §f[-754, 53, -5299]",
     "length": "long",
     "lengthInfo": "3m",
@@ -1796,7 +1801,7 @@
   {
     "type": "cave",
     "name": "Naga Dugout",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7A sneaky Naga Commander has made camp in a dugout at §f[-2025, 59, -5081]",
     "length": "long",
     "lengthInfo": "2m",
@@ -1804,6 +1809,7 @@
     "requirements": 58,
     "rewards": [
       "40000 XP",
+      "2 Az Runes",
       "Various Items"
     ],
     "location": {
@@ -1834,7 +1840,7 @@
   {
     "type": "cave",
     "name": "Nymph Towers",
-    "specialInfo": "Rock Towers",
+    "specialInfo": "§eRock Towers",
     "description": "§7Climb the earthen towers and find what treasure the nymphs have at §f[-1052, 46, -4768]",
     "length": "medium",
     "lengthInfo": "1m45s",
@@ -1871,25 +1877,6 @@
   },
   {
     "type": "cave",
-    "name": "Orc Cove",
-    "specialInfo": "",
-    "description": "§7Ridiculous rumors state an orc camp full of ruin-seekers lies beneath a lake §f[-1827, 53, -4899]",
-    "length": "short",
-    "lengthInfo": "40s",
-    "difficulty": "easy",
-    "requirements": 46,
-    "rewards": [
-      "14000 XP",
-      "Various Items"
-    ],
-    "location": {
-      "x": -1827,
-      "y": 53,
-      "z": -4899
-    }
-  },
-  {
-    "type": "cave",
     "name": "Overgrown Rubble",
     "specialInfo": "",
     "description": "§7An overgrown cave has gone to rubble and caved in! Trek through the rubble and find what's inside at §f[742, 87, -4890]",
@@ -1910,7 +1897,7 @@
   {
     "type": "cave",
     "name": "Ovine Spire",
-    "specialInfo": "Tower",
+    "specialInfo": "§eTower",
     "description": "§7A cabal of fluffy jumbucks have established a Guard Tower at §f[778, 81, -4721]",
     "length": "long",
     "lengthInfo": "2m30s",
@@ -1928,7 +1915,7 @@
   },
   {
     "type": "cave",
-    "name": "Pigman Outpost",
+    "name": "Pigman Barbeque",
     "specialInfo": "",
     "description": "§7Pigmen are cooking up something outside Ragni at §f[-622, 69, -1570]",
     "length": "short",
@@ -1938,7 +1925,7 @@
     "rewards": [
       "30 XP",
       "13 Emeralds",
-      "1 Blank",
+      "1 §eBlank",
       "Various Items"
     ],
     "location": {
@@ -1988,7 +1975,7 @@
   {
     "type": "cave",
     "name": "Pirate Sloop",
-    "specialInfo": "Dock",
+    "specialInfo": "§eDock",
     "description": "§7Find the pirates dock to their hideout at §f[-1341, 35, -2229]",
     "length": "medium",
     "lengthInfo": "1m",
@@ -2064,7 +2051,7 @@
   {
     "type": "cave",
     "name": "Raging Tower",
-    "specialInfo": "Tower",
+    "specialInfo": "§eTower",
     "description": "§7An old tower overtaken by fiery corrupt with a powerful being looming overtop at §f[144, 68, -1680]",
     "length": "medium",
     "lengthInfo": "1m10s",
@@ -2319,6 +2306,7 @@
     "requirements": 57,
     "rewards": [
       "40000 XP",
+      "3 Az Runes",
       "Various Items"
     ],
     "location": {
@@ -2330,7 +2318,7 @@
   {
     "type": "cave",
     "name": "Shadow Altar",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7Fill the altar and fight what lives inside at §f[1271, 95, -5427]",
     "length": "medium",
     "lengthInfo": "1m40s",
@@ -2363,6 +2351,26 @@
       "x": 1339,
       "y": 33,
       "z": -1552
+    }
+  },
+  {
+    "type": "cave",
+    "name": "Shineridge Orc Camp",
+    "specialInfo": "§eCamp",
+    "description": "§7The Orcish traders and jewelers gather riches at Shineridge, enough to make Llevigar traders jealous §f[-1621, 47, -4664]",
+    "length": "long",
+    "lengthInfo": "3m",
+    "difficulty": "hard",
+    "requirements": 45,
+    "rewards": [
+      "20000 XP",
+      "2 Az Runes",
+      "Various Items"
+    ],
+    "location": {
+      "x": -1621,
+      "y": 47,
+      "z": -4664
     }
   },
   {
@@ -2414,6 +2422,7 @@
     "requirements": 55,
     "rewards": [
       "40000 XP",
+      "2 Az Runes",
       "Various Items"
     ],
     "location": {
@@ -2444,7 +2453,7 @@
   {
     "type": "cave",
     "name": "Sky Shroom",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7A strange shroom grows up around §f[1199, 108, -4289]",
     "length": "medium",
     "lengthInfo": "1m30s",
@@ -2595,6 +2604,26 @@
   },
   {
     "type": "cave",
+    "name": "Sundial Sanctum",
+    "specialInfo": "§eCave Complex",
+    "description": "§7Enter The Sanctum at §f[1062, 73, -1726]§7 if you dare §d󐀄§bSailers",
+    "length": "long",
+    "lengthInfo": "15m",
+    "difficulty": "hard",
+    "requirements": 35,
+    "rewards": [
+      "10000 XP",
+      "1 §bUnidentified Solar",
+      "Various Items"
+    ],
+    "location": {
+      "x": 1062,
+      "y": 73,
+      "z": -1726
+    }
+  },
+  {
+    "type": "cave",
     "name": "Sunken Ship",
     "specialInfo": "",
     "description": "§7Off Nemract's coast lies treasure sunken under a shipwreck at §f[215, 34, -2410]§7, too far underwater to reach without special equipment",
@@ -2623,6 +2652,7 @@
     "requirements": 50,
     "rewards": [
       "40000 XP",
+      "1 Az Rune",
       "Various Items"
     ],
     "location": {
@@ -2653,7 +2683,7 @@
   {
     "type": "cave",
     "name": "Termite Mounds",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7Termite Mounds across the Savannah! Find one of the entrances to their maze of tunnels and treasures at §f[727, 76, -1707]",
     "length": "long",
     "lengthInfo": "3m",
@@ -2734,9 +2764,9 @@
     "length": "medium",
     "lengthInfo": "1m",
     "difficulty": "hard",
-    "requirements": 69,
+    "requirements": 72,
     "rewards": [
-      "15000 XP",
+      "50000 XP",
       "Various Items"
     ],
     "location": {
@@ -2824,7 +2854,7 @@
   {
     "type": "cave",
     "name": "The Sacrificial Altar",
-    "specialInfo": "Boss Cave",
+    "specialInfo": "§eBoss Cave",
     "description": "§7Dark Cultists have gathered around an Altar in a cliffside cave around §f[-298, 38, -969]",
     "length": "medium",
     "lengthInfo": "1m30s",
@@ -2843,7 +2873,7 @@
   {
     "type": "cave",
     "name": "The Warehouse",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7Bots manage a complex warehouse deep in the ground at §f[-1847, 41, -2641]",
     "length": "long",
     "lengthInfo": "3m",
@@ -3000,9 +3030,9 @@
     "length": "medium",
     "lengthInfo": "1m",
     "difficulty": "easy",
-    "requirements": 51,
+    "requirements": 60,
     "rewards": [
-      "14000 XP",
+      "45000 XP",
       "Various Items"
     ],
     "location": {
@@ -3071,7 +3101,7 @@
   {
     "type": "cave",
     "name": "Vortex Complex",
-    "specialInfo": "Cave Complex",
+    "specialInfo": "§eCave Complex",
     "description": "§7Enter this deep and confusing complex and find what treasure lies within §f[-182, 71, -1210]",
     "length": "long",
     "lengthInfo": "3m",
@@ -3147,7 +3177,7 @@
   {
     "type": "cave",
     "name": "Weirding Ring",
-    "specialInfo": "Tower",
+    "specialInfo": "§eTower",
     "description": "§7Instead of fae spirits, Weirds have congealed in a ring of giant climbable mushrooms at §f[-498, 41, -5293]",
     "length": "long",
     "lengthInfo": "2m",

--- a/Reference/combat_mapfeatures.json
+++ b/Reference/combat_mapfeatures.json
@@ -108,12 +108,12 @@
     "categoryId": "wynntils:content:dungeon",
     "attributes": {
       "label": "Decrepit Sewers",
-      "level": 9
+      "level": 8
     },
     "location": {
-      "x": -922,
-      "y": 65,
-      "z": -1885
+      "x": -926,
+      "y": 62,
+      "z": -1888
     }
   },
   {
@@ -173,12 +173,12 @@
     "categoryId": "wynntils:content:dungeon",
     "attributes": {
       "label": "Infested Pit",
-      "level": 18
+      "level": 17
     },
     "location": {
-      "x": -282,
-      "y": 35,
-      "z": -1829
+      "x": -199,
+      "y": 53,
+      "z": -1854
     }
   },
   {
@@ -215,9 +215,9 @@
       "level": 54
     },
     "location": {
-      "x": -635,
-      "y": 59,
-      "z": -864
+      "x": -642,
+      "y": 73,
+      "z": -854
     }
   },
   {
@@ -225,7 +225,7 @@
     "categoryId": "wynntils:content:dungeon",
     "attributes": {
       "label": "Underworld Crypt",
-      "level": 24
+      "level": 23
     },
     "location": {
       "x": 288,
@@ -238,12 +238,12 @@
     "categoryId": "wynntils:content:raid",
     "attributes": {
       "label": "Nest of the Grootslangs",
-      "level": 55
+      "level": 54
     },
     "location": {
       "x": -1977,
       "y": 63,
-      "z": -5614
+      "z": -5635
     }
   },
   {
@@ -251,12 +251,12 @@
     "categoryId": "wynntils:content:raid",
     "attributes": {
       "label": "Orphion's Nexus of Light",
-      "level": 80
+      "level": 79
     },
     "location": {
-      "x": -731,
+      "x": -732,
       "y": 100,
-      "z": -6411
+      "z": -6435
     }
   },
   {
@@ -264,12 +264,12 @@
     "categoryId": "wynntils:content:raid",
     "attributes": {
       "label": "The Canyon Colossus",
-      "level": 90
+      "level": 95
     },
     "location": {
-      "x": 656,
-      "y": 48,
-      "z": -4447
+      "x": 693,
+      "y": 44,
+      "z": -4448
     }
   },
   {
@@ -277,12 +277,12 @@
     "categoryId": "wynntils:content:raid",
     "attributes": {
       "label": "The Nameless Anomaly",
-      "level": 105
+      "level": 103
     },
     "location": {
-      "x": 1116,
-      "y": 84,
-      "z": -907
+      "x": 1068,
+      "y": 106,
+      "z": -824
     }
   },
   {
@@ -465,6 +465,19 @@
       "x": 1323,
       "y": 33,
       "z": -4611
+    }
+  },
+  {
+    "featureId": "canyon-of-the-lost-excursion-south",
+    "categoryId": "wynntils:content:lootrun-camp",
+    "attributes": {
+      "label": "Canyon of the Lost Excursion (South)",
+      "level": 85
+    },
+    "location": {
+      "x": 578,
+      "y": 79,
+      "z": -5018
     }
   },
   {
@@ -790,19 +803,6 @@
       "x": 1134,
       "y": 135,
       "z": -1121
-    }
-  },
-  {
-    "featureId": "cannibal-walkways",
-    "categoryId": "wynntils:content:cave",
-    "attributes": {
-      "label": "Cannibal Walkways",
-      "level": 71
-    },
-    "location": {
-      "x": -956,
-      "y": 43,
-      "z": -525
     }
   },
   {
@@ -1219,6 +1219,19 @@
       "x": 1301,
       "y": 86,
       "z": -2144
+    }
+  },
+  {
+    "featureId": "fallen-salient",
+    "categoryId": "wynntils:content:cave",
+    "attributes": {
+      "label": "Fallen Salient",
+      "level": 71
+    },
+    "location": {
+      "x": -956,
+      "y": 43,
+      "z": -525
     }
   },
   {
@@ -1794,19 +1807,6 @@
     }
   },
   {
-    "featureId": "orc-cove",
-    "categoryId": "wynntils:content:cave",
-    "attributes": {
-      "label": "Orc Cove",
-      "level": 46
-    },
-    "location": {
-      "x": -1827,
-      "y": 53,
-      "z": -4899
-    }
-  },
-  {
     "featureId": "overgrown-rubble",
     "categoryId": "wynntils:content:cave",
     "attributes": {
@@ -1833,10 +1833,10 @@
     }
   },
   {
-    "featureId": "pigman-outpost",
+    "featureId": "pigman-barbeque",
     "categoryId": "wynntils:content:cave",
     "attributes": {
-      "label": "Pigman Outpost",
+      "label": "Pigman Barbeque",
       "level": 1
     },
     "location": {
@@ -2132,6 +2132,19 @@
     }
   },
   {
+    "featureId": "shineridge-orc-camp",
+    "categoryId": "wynntils:content:cave",
+    "attributes": {
+      "label": "Shineridge Orc Camp",
+      "level": 45
+    },
+    "location": {
+      "x": -1621,
+      "y": 47,
+      "z": -4664
+    }
+  },
+  {
     "featureId": "shock-shrine",
     "categoryId": "wynntils:content:cave",
     "attributes": {
@@ -2288,6 +2301,19 @@
     }
   },
   {
+    "featureId": "sundial-sanctum",
+    "categoryId": "wynntils:content:cave",
+    "attributes": {
+      "label": "Sundial Sanctum",
+      "level": 35
+    },
+    "location": {
+      "x": 1062,
+      "y": 73,
+      "z": -1726
+    }
+  },
+  {
     "featureId": "sunken-ship",
     "categoryId": "wynntils:content:cave",
     "attributes": {
@@ -2383,7 +2409,7 @@
     "categoryId": "wynntils:content:cave",
     "attributes": {
       "label": "The Heartwood",
-      "level": 69
+      "level": 72
     },
     "location": {
       "x": -625,
@@ -2565,7 +2591,7 @@
     "categoryId": "wynntils:content:cave",
     "attributes": {
       "label": "Trunk Garrison",
-      "level": 51
+      "level": 60
     },
     "location": {
       "x": -560,


### PR DESCRIPTION
Unfortunately, combat locations do not have a script to automatically update, and I've only added one for mapdata a few weeks ago, so until we finish mapdata, combat locations will be slightly off (except caves).