### PR TITLE
Revert "chore: bump version number on md5sum change (#153)"

### DIFF
--- a/Generators/extract_caves.sh
+++ b/Generators/extract_caves.sh
@@ -13,10 +13,4 @@ MD5=$(md5sum $OUTPUT_DIR/caves.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticCaveInfo
 jq '. = [.[] | if (.id == "dataStaticCaveInfo") then (.md5 = "'$MD5'") else . end]' < $BASE_DIR/Data-Storage/urls.json > $BASE_DIR/Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < $BASE_DIR/Data-Storage/urls.json.tmp > $BASE_DIR/Data-Storage/urls.json
-fi
-
-rm $BASE_DIR/Data-Storage/urls.json.tmp
+mv $BASE_DIR/Data-Storage/urls.json.tmp $BASE_DIR/Data-Storage/urls.json

--- a/Generators/extract_combat_locations.sh
+++ b/Generators/extract_combat_locations.sh
@@ -66,10 +66,4 @@ MD5=$(md5sum $OUTPUT_DIR/combat_mapfeatures.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticCombatMapFeatures
 jq '. = [.[] | if (.id == "dataStaticCombatMapFeatures") then (.md5 = "'$MD5'") else . end]' < $BASE_DIR/Data-Storage/urls.json > $BASE_DIR/Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < $BASE_DIR/Data-Storage/urls.json.tmp > $BASE_DIR/Data-Storage/urls.json
-fi
-
-rm $BASE_DIR/Data-Storage/urls.json.tmp
+mv $BASE_DIR/Data-Storage/urls.json.tmp $BASE_DIR/Data-Storage/urls.json

--- a/Generators/extract_labels.sh
+++ b/Generators/extract_labels.sh
@@ -130,12 +130,6 @@ MD5=$(md5sum $TARGET_MAPFEATURES | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticPlaceMapFeatures
 jq '. = [.[] | if (.id == "dataStaticPlaceMapFeatures") then (.md5 = "'$MD5'") else . end]' < $MYDIR/../Data-Storage/urls.json > $MYDIR/../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < $BASE_DIR/Data-Storage/urls.json.tmp > $BASE_DIR/Data-Storage/urls.json
-fi
-
-rm $BASE_DIR/Data-Storage/urls.json.tmp
+mv $MYDIR/../Data-Storage/urls.json.tmp $MYDIR/../Data-Storage/urls.json
 
 echo Finished updating "$TARGET_MAPFEATURES"

--- a/Generators/extract_services.sh
+++ b/Generators/extract_services.sh
@@ -145,10 +145,4 @@ MD5=$(md5sum $TARGET_DIR/$TARGET_MAPFEATURES | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticServicesMapFeatures
 jq '. = [.[] | if (.id == "dataStaticServicesMapFeatures") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/merge_abilities.sh
+++ b/Generators/merge_abilities.sh
@@ -25,10 +25,4 @@ MD5=$(md5sum "$COMBINED_JSON" | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticAbilities
 jq --arg md5 "$MD5" '. = [.[] | if (.id == "dataStaticAbilities") then .md5 = $md5 else . end]' < "$BASE_DIR"/Data-Storage/urls.json > "$BASE_DIR"/Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < $BASE_DIR/Data-Storage/urls.json.tmp > $BASE_DIR/Data-Storage/urls.json
-fi
-
-rm $BASE_DIR/Data-Storage/urls.json.tmp
+mv "$BASE_DIR"/Data-Storage/urls.json.tmp "$BASE_DIR"/Data-Storage/urls.json

--- a/Generators/update_charm_data.sh
+++ b/Generators/update_charm_data.sh
@@ -35,10 +35,4 @@ MD5=$(md5sum $TARGET_DIR/charms.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticCharms
 jq '. = [.[] | if (.id == "dataStaticCharms") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/update_gear_data.sh
+++ b/Generators/update_gear_data.sh
@@ -35,10 +35,4 @@ MD5=$(md5sum $TARGET_DIR/gear.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticGear
 jq '. = [.[] | if (.id == "dataStaticGear") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/update_identification_keys.sh
+++ b/Generators/update_identification_keys.sh
@@ -59,10 +59,4 @@ MD5=$(md5sum $TARGET_DIR/id_keys.json | cut -d' ' -f1)
 
 # Update ulrs.json with the new md5sum for dataStaticIdentificationKeys
 jq '. = [.[] | if (.id == "dataStaticIdentificationKeys") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/update_ingredient_data.sh
+++ b/Generators/update_ingredient_data.sh
@@ -35,10 +35,4 @@ MD5=$(md5sum $TARGET_DIR/advanced_ingredients.json | cut -d' ' -f1)
 
 # Update ulrs.json with the new md5sum for dataStaticIngredientsAdvanced
 jq '. = [.[] | if (.id == "dataStaticIngredientsAdvanced") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/update_maps.sh
+++ b/Generators/update_maps.sh
@@ -217,12 +217,6 @@ MD5=$(md5sum $JSON_METADATA_FILE | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticMaps
 jq '. = [.[] | if (.id == "dataStaticMaps") then (.md5 = "'$MD5'") else . end]' < $WYNNDATA_DIR/Data-Storage/urls.json > $WYNNDATA_DIR/Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < $WYNNDATA_DIR/Data-Storage/urls.json.tmp > $WYNNDATA_DIR/Data-Storage/urls.json
-fi
-
-rm $WYNNDATA_DIR/Data-Storage/urls.json.tmp
+mv $WYNNDATA_DIR/Data-Storage/urls.json.tmp $WYNNDATA_DIR/Data-Storage/urls.json
 
 rm -rf $WYNNDATA_DIR/tmp

--- a/Generators/update_material_data.sh
+++ b/Generators/update_material_data.sh
@@ -35,10 +35,4 @@ MD5=$(md5sum $TARGET_DIR/materials.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticMaterials
 jq '. = [.[] | if (.id == "dataStaticMaterials") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/update_tome_data.sh
+++ b/Generators/update_tome_data.sh
@@ -35,10 +35,4 @@ MD5=$(md5sum $TARGET_DIR/tomes.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticTomes
 jq '. = [.[] | if (.id == "dataStaticTomes") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json

--- a/Generators/update_tool_data.sh
+++ b/Generators/update_tool_data.sh
@@ -35,10 +35,4 @@ MD5=$(md5sum $TARGET_DIR/tools.json | cut -d' ' -f1)
 
 # Update urls.json with the new md5sum for dataStaticTools
 jq '. = [.[] | if (.id == "dataStaticTools") then (.md5 = "'$MD5'") else . end]' < ../Data-Storage/urls.json > ../Data-Storage/urls.json.tmp
-
-# If the temp file is different from the original, bump the version number
-if ! cmp -s ../Data-Storage/urls.json ../Data-Storage/urls.json.tmp; then
-    jq 'map(if has("version") then .version += 1 else . end)' < ../Data-Storage/urls.json.tmp > ../Data-Storage/urls.json
-fi
-
-rm ../Data-Storage/urls.json.tmp
+mv ../Data-Storage/urls.json.tmp ../Data-Storage/urls.json


### PR DESCRIPTION
This reverts commit d288c9d3486590b13a23fc2b3a61795ef1cd9cac.

We've agreed that this is not the best solution to the problem. Let's not do any new versioning for now, just revert the change.