### PR TITLE
fix: add missing items in item conversion map

### DIFF
--- a/Data-Storage/material_conversions.json
+++ b/Data-Storage/material_conversions.json
@@ -817,7 +817,7 @@
   {
     "id": 356,
     "type": 0,
-    "name": "redstone_repeater"
+    "name": "repeater"
   },
   {
     "id": 357,

--- a/Data-Storage/material_conversions.json
+++ b/Data-Storage/material_conversions.json
@@ -265,6 +265,11 @@
     "name": "cactus"
   },
   {
+    "id": 86,
+    "type": 0,
+    "name": "pumpkin"
+  },
+  {
     "id": 87,
     "type": 0,
     "name": "netherrack"

--- a/Data-Storage/material_conversions.json
+++ b/Data-Storage/material_conversions.json
@@ -527,7 +527,7 @@
   {
     "id": 257,
     "type": 0,
-    "name": "iron_shovel"
+    "name": "iron_pickaxe"
   },
   {
     "id": 259,

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -170,7 +170,7 @@
   },
   {
     "id": "dataStaticMaterialConversion",
-    "md5": "12f3c916d96c2c1fa45edb71c3da07e6",
+    "md5": "88408188ba3a5068950db7f912e7f4ab",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/material_conversions.json"
   },
   {

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -170,7 +170,7 @@
   },
   {
     "id": "dataStaticMaterialConversion",
-    "md5": "e4b509c5e14cd40fc5c348687579e942",
+    "md5": "12f3c916d96c2c1fa45edb71c3da07e6",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/material_conversions.json"
   },
   {

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -170,7 +170,7 @@
   },
   {
     "id": "dataStaticMaterialConversion",
-    "md5": "88408188ba3a5068950db7f912e7f4ab",
+    "md5": "d9aa877ab5c05e35ccb2b0f2de1829b7",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/material_conversions.json"
   },
   {


### PR DESCRIPTION
Pumpkin Helmet uses the pumpkin texture (86) and was missed in the original run through