### PR TITLE
fix: fix sign item in item conversion map

### DIFF
--- a/Data-Storage/material_conversions.json
+++ b/Data-Storage/material_conversions.json
@@ -682,7 +682,7 @@
   {
     "id": 323,
     "type": 0,
-    "name": "sign"
+    "name": "oak_sign"
   },
   {
     "id": 325,

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -170,7 +170,7 @@
   },
   {
     "id": "dataStaticMaterialConversion",
-    "md5": "d9aa877ab5c05e35ccb2b0f2de1829b7",
+    "md5": "a4ec63ebbd23003dc6627fed738f8c24",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/material_conversions.json"
   },
   {


### PR DESCRIPTION
minecraft:sign no longer exists,
minecraft:oak_sign is the texture used by wynn