### PR TITLE
fix: Change Troll Den Z coordinate

### DIFF
--- a/Data-Storage/lootrun_tasks_named_v2.json
+++ b/Data-Storage/lootrun_tasks_named_v2.json
@@ -867,7 +867,7 @@
       "location": {
         "x": 537,
         "y": 24,
-        "z": -4932
+        "z": -4927
       },
       "name": "Troll Den",
       "taskType": "slay"

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -165,7 +165,7 @@
   },
   {
     "id": "dataStaticLootrunTasksNamedV2",
-    "md5": "c8a56fdbc7a0fd65750ed6c343e0e0fd",
+    "md5": "6db37c08ce37d1826e58c90a2d7bcd01",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/lootrun_tasks_named_v2.json"
   },
   {


### PR DESCRIPTION
Not sure if this was recently changed or an error in the original collection but either way we have the wrong z

![2025-03-30_14 01 19](https://github.com/user-attachments/assets/453eaad6-3923-4d7a-9793-dde56de74770)
