### PR TITLE
fix: Exit early if invalid json returned in workflows

### DIFF
--- a/Generators/extract_services.sh
+++ b/Generators/extract_services.sh
@@ -16,8 +16,8 @@ if [ ! -s markers.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' markers.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' markers.json.tmp > /dev/null; then
     rm markers.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_aspect_data.sh
+++ b/Generators/update_aspect_data.sh
@@ -17,8 +17,8 @@ if [ ! -s classes.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' classes.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' classes.json.tmp > /dev/null; then
     rm classes.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit
@@ -38,8 +38,8 @@ for CLASS in $ASPECT_CLASSES; do
         exit
     fi
 
-    # Check if the file is a JSON with a single "message" key
-    if jq -e 'length == 1 and has("message")' ${CLASS}_aspects.json.tmp > /dev/null; then
+    # Check if the file is a JSON with a "message" and "request_id" key
+    if jq -e 'length == 2 and has("message") and has("request_id")' ${CLASS}_aspects.json.tmp > /dev/null; then
         rm ${CLASS}_aspects.json.tmp
         echo "Error: Wynncraft API returned an error message for $CLASS, aborting"
         exit

--- a/Generators/update_charm_data.sh
+++ b/Generators/update_charm_data.sh
@@ -14,8 +14,8 @@ if [ ! -s charms.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' charms.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' charms.json.tmp > /dev/null; then
     rm charms.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_gear_data.sh
+++ b/Generators/update_gear_data.sh
@@ -14,8 +14,8 @@ if [ ! -s gear.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' gear.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' gear.json.tmp > /dev/null; then
     rm gear.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_identification_keys.sh
+++ b/Generators/update_identification_keys.sh
@@ -13,8 +13,8 @@ if [ ! -s metadata.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' metadata.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' metadata.json.tmp > /dev/null; then
     rm metadata.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_ingredient_data.sh
+++ b/Generators/update_ingredient_data.sh
@@ -14,8 +14,8 @@ if [ ! -s ingredients.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' ingredients.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' ingredients.json.tmp > /dev/null; then
     rm ingredients.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_material_data.sh
+++ b/Generators/update_material_data.sh
@@ -14,8 +14,8 @@ if [ ! -s materials.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' materials.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' materials.json.tmp > /dev/null; then
     rm materials.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_tome_data.sh
+++ b/Generators/update_tome_data.sh
@@ -14,8 +14,8 @@ if [ ! -s tomes.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' tomes.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' tomes.json.tmp > /dev/null; then
     rm tomes.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit

--- a/Generators/update_tool_data.sh
+++ b/Generators/update_tool_data.sh
@@ -14,8 +14,8 @@ if [ ! -s tools.json.tmp ]; then
     exit
 fi
 
-# Check if the file is a JSON with a single "message" key
-if jq -e 'length == 1 and has("message")' tools.json.tmp > /dev/null; then
+# Check if the file is a JSON with a "message" and "request_id" key
+if jq -e 'length == 2 and has("message") and has("request_id")' tools.json.tmp > /dev/null; then
     rm tools.json.tmp
     echo "Error: Wynncraft API returned an error message, aborting"
     exit


### PR DESCRIPTION
Should stop the scripts from triggering when the API is down