### PR TITLE
fix: identification keys not parsing

### DIFF
--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -161,7 +161,7 @@
   },
   {
     "id": "dataStaticIdentificationKeys",
-    "md5": "745366b87899dfa650e7a9a2b0d5f4d3",
+    "md5": "a6617793c2790b7cafc222f6c54e7e27",
     "path": "Reference/id_keys.json",
     "url": "https://cdn.wynntils.com/static/Reference/id_keys.json"
   },

--- a/Generators/update_identification_keys.sh
+++ b/Generators/update_identification_keys.sh
@@ -27,7 +27,7 @@ if jq -e '(length == 2 and has("message") and has("request_id")) or has("error")
     exit
 fi
 
-jq --sort-keys '.identifications | sort | values[]' < metadata.json.tmp > ids.tmp
+jq --sort-keys '.filters.identifications | sort | values[]' < metadata.json.tmp > ids.tmp
 
 rm metadata.json.tmp
 

--- a/Reference/id_keys.json
+++ b/Reference/id_keys.json
@@ -119,5 +119,8 @@
   "rawMaxMana": 117,
   "mainAttackRange": 118,
   "criticalDamageBonus": 119,
-  "mainAttackFireDamage": 120
+  "mainAttackFireDamage": 120,
+  "combatExperience": 121,
+  "gatheringExperience": 122,
+  "waterMainAttackDamage": 123
 }


### PR DESCRIPTION
Wynncraft changed the structure of the metadata endpoint, this PR fixes it and updates the identification keys