### PR TITLE
feat: add generator scripts for new map API endpoints

### DIFF
--- a/.github/workflows/update_gathering_nodes.yml
+++ b/.github/workflows/update_gathering_nodes.yml
@@ -1,0 +1,36 @@
+# Github actions runner will run this script on a schedule
+
+name: Update Gathering Nodes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight
+
+jobs:
+  update-gathering-nodes:
+    runs-on: ubuntu-latest
+    env:
+      WYNNCRAFT_API_KEY: ${{ secrets.WYNNCRAFT_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Update Gathering Nodes Data
+        run: |
+          chmod +x ./Generators/extract_gathering_nodes.sh
+          ./Generators/extract_gathering_nodes.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.2
+        with:
+            token: ${{ secrets.PRIVATE_TOKEN }}
+            labels: auto-generated
+            committer: 'WynntilsBot <admin@wynntils.com>'
+            author: 'WynntilsBot <admin@wynntils.com>'
+            commit-message: "chore: [auto-generated] Update gathering nodes data from upstream"
+            title: "chore: [auto-generated] Update gathering nodes data from upstream"
+            body: |
+              Upstream Wynncraft API has been updated with new gathering nodes data.
+
+              This PR has been automatically generated.
+            branch: update-gathering-nodes-data

--- a/.github/workflows/update_map_camps.yml
+++ b/.github/workflows/update_map_camps.yml
@@ -1,0 +1,36 @@
+# Github actions runner will run this script on a schedule
+
+name: Update Map Camps
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight
+
+jobs:
+  update-map-camps:
+    runs-on: ubuntu-latest
+    env:
+      WYNNCRAFT_API_KEY: ${{ secrets.WYNNCRAFT_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Update Map Camps Data
+        run: |
+          chmod +x ./Generators/extract_map_camps.sh
+          ./Generators/extract_map_camps.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.2
+        with:
+            token: ${{ secrets.PRIVATE_TOKEN }}
+            labels: auto-generated
+            committer: 'WynntilsBot <admin@wynntils.com>'
+            author: 'WynntilsBot <admin@wynntils.com>'
+            commit-message: "chore: [auto-generated] Update map camps data from upstream"
+            title: "chore: [auto-generated] Update map camps data from upstream"
+            body: |
+              Upstream Wynncraft API has been updated with new map camps data.
+
+              This PR has been automatically generated.
+            branch: update-map-camps-data

--- a/.github/workflows/update_map_loot_pools.yml
+++ b/.github/workflows/update_map_loot_pools.yml
@@ -1,0 +1,36 @@
+# Github actions runner will run this script on a schedule
+
+name: Update Map Loot Pools
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight
+
+jobs:
+  update-map-loot-pools:
+    runs-on: ubuntu-latest
+    env:
+      WYNNCRAFT_API_KEY: ${{ secrets.WYNNCRAFT_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Update Map Loot Pools Data
+        run: |
+          chmod +x ./Generators/extract_map_loot_pools.sh
+          ./Generators/extract_map_loot_pools.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.2
+        with:
+            token: ${{ secrets.PRIVATE_TOKEN }}
+            labels: auto-generated
+            committer: 'WynntilsBot <admin@wynntils.com>'
+            author: 'WynntilsBot <admin@wynntils.com>'
+            commit-message: "chore: [auto-generated] Update map loot pools data from upstream"
+            title: "chore: [auto-generated] Update map loot pools data from upstream"
+            body: |
+              Upstream Wynncraft API has been updated with new map loot pools data.
+
+              This PR has been automatically generated.
+            branch: update-map-loot-pools-data

--- a/.github/workflows/update_map_raids.yml
+++ b/.github/workflows/update_map_raids.yml
@@ -1,0 +1,36 @@
+# Github actions runner will run this script on a schedule
+
+name: Update Map Raids
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight
+
+jobs:
+  update-map-raids:
+    runs-on: ubuntu-latest
+    env:
+      WYNNCRAFT_API_KEY: ${{ secrets.WYNNCRAFT_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Update Map Raids Data
+        run: |
+          chmod +x ./Generators/extract_map_raids.sh
+          ./Generators/extract_map_raids.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.2
+        with:
+            token: ${{ secrets.PRIVATE_TOKEN }}
+            labels: auto-generated
+            committer: 'WynntilsBot <admin@wynntils.com>'
+            author: 'WynntilsBot <admin@wynntils.com>'
+            commit-message: "chore: [auto-generated] Update map raids data from upstream"
+            title: "chore: [auto-generated] Update map raids data from upstream"
+            body: |
+              Upstream Wynncraft API has been updated with new map raids data.
+
+              This PR has been automatically generated.
+            branch: update-map-raids-data

--- a/.github/workflows/update_world_events.yml
+++ b/.github/workflows/update_world_events.yml
@@ -1,0 +1,36 @@
+# Github actions runner will run this script on a schedule
+
+name: Update World Events
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *' # Runs every hour
+
+jobs:
+  update-world-events:
+    runs-on: ubuntu-latest
+    env:
+      WYNNCRAFT_API_KEY: ${{ secrets.WYNNCRAFT_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Update World Events Data
+        run: |
+          chmod +x ./Generators/extract_world_events.sh
+          ./Generators/extract_world_events.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.2
+        with:
+            token: ${{ secrets.PRIVATE_TOKEN }}
+            labels: auto-generated
+            committer: 'WynntilsBot <admin@wynntils.com>'
+            author: 'WynntilsBot <admin@wynntils.com>'
+            commit-message: "chore: [auto-generated] Update world events data from upstream"
+            title: "chore: [auto-generated] Update world events data from upstream"
+            body: |
+              Upstream Wynncraft API has been updated with new world events data.
+
+              This PR has been automatically generated.
+            branch: update-world-events-data

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -142,6 +142,12 @@
     "url": "https://cdn.wynntils.com/static/Data-Storage/destinations.json"
   },
   {
+    "id": "dataStaticGatheringNodes",
+    "md5": "",
+    "path": "Reference/gathering_nodes.json",
+    "url": "https://cdn.wynntils.com/static/Reference/gathering_nodes.json"
+  },
+  {
     "id": "dataStaticGear",
     "md5": "48e4e8f1e7db05aa65c3a6e320295682",
     "path": "Reference/gear.json",
@@ -152,12 +158,6 @@
     "md5": "7cc0f3d523b1423e11f5fcb7a508c2d9",
     "path": "Reference/advanced_gear.json",
     "url": "https://cdn.wynntils.com/static/Reference/advanced_gear.json"
-  },
-  {
-    "id": "dataStaticGatheringNodes",
-    "md5": "",
-    "path": "Reference/gathering_nodes.json",
-    "url": "https://cdn.wynntils.com/static/Reference/gathering_nodes.json"
   },
   {
     "id": "dataStaticHints",
@@ -334,15 +334,15 @@
     "url": "https://cdn.wynntils.com/static/Reference/tools.json"
   },
   {
+    "id": "dataStaticUrls",
+    "path": "Data-Storage/urls.json",
+    "url": "https://cdn.wynntils.com/static/Data-Storage/urls.json"
+  },
+  {
     "id": "dataStaticWorldEvents",
     "md5": "",
     "path": "Reference/world_events.json",
     "url": "https://cdn.wynntils.com/static/Reference/world_events.json"
-  },
-  {
-    "id": "dataStaticUrls",
-    "path": "Data-Storage/urls.json",
-    "url": "https://cdn.wynntils.com/static/Data-Storage/urls.json"
   },
   {
     "arguments": [

--- a/Data-Storage/urls.json
+++ b/Data-Storage/urls.json
@@ -154,6 +154,12 @@
     "url": "https://cdn.wynntils.com/static/Reference/advanced_gear.json"
   },
   {
+    "id": "dataStaticGatheringNodes",
+    "md5": "",
+    "path": "Reference/gathering_nodes.json",
+    "url": "https://cdn.wynntils.com/static/Reference/gathering_nodes.json"
+  },
+  {
     "id": "dataStaticHints",
     "md5": "315e1cfbd8fbbc6d6940fd29a76f4472",
     "path": "Data-Storage/hint_messages.json",
@@ -218,6 +224,24 @@
     "md5": "38bb5299f66016271f5bf3a1f49ec0ae",
     "path": "Data-Storage/major_ids.json",
     "url": "https://cdn.wynntils.com/static/Data-Storage/major_ids.json"
+  },
+  {
+    "id": "dataStaticMapCamps",
+    "md5": "",
+    "path": "Reference/map_camps.json",
+    "url": "https://cdn.wynntils.com/static/Reference/map_camps.json"
+  },
+  {
+    "id": "dataStaticMapLootPools",
+    "md5": "",
+    "path": "Reference/map_loot_pools.json",
+    "url": "https://cdn.wynntils.com/static/Reference/map_loot_pools.json"
+  },
+  {
+    "id": "dataStaticMapRaids",
+    "md5": "",
+    "path": "Reference/map_raids.json",
+    "url": "https://cdn.wynntils.com/static/Reference/map_raids.json"
   },
   {
     "id": "dataStaticMaps",
@@ -308,6 +332,12 @@
     "md5": "ea93ac47d7cfccc2d4db7e1bdcb8873f",
     "path": "Reference/tools.json",
     "url": "https://cdn.wynntils.com/static/Reference/tools.json"
+  },
+  {
+    "id": "dataStaticWorldEvents",
+    "md5": "",
+    "path": "Reference/world_events.json",
+    "url": "https://cdn.wynntils.com/static/Reference/world_events.json"
   },
   {
     "id": "dataStaticUrls",

--- a/Generators/extract_gathering_nodes.sh
+++ b/Generators/extract_gathering_nodes.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TARGET_DIR=$(cd $(dirname "$0")/.. >/dev/null 2>&1 && pwd)/Reference
+
+if [ -z "${WYNNCRAFT_API_KEY:-}" ]; then
+    echo "Error: WYNNCRAFT_API_KEY is not set"
+    exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer ${WYNNCRAFT_API_KEY}"
+
+TARGET="gathering_nodes.json"
+
+wget --header="$AUTH_HEADER" -O "$TARGET_DIR/$TARGET.tmp" "https://api.wynncraft.com/v3/map/gathering-nodes"
+
+if [ ! -s "$TARGET_DIR/$TARGET.tmp" ]; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API is not working, aborting"
+    exit 1
+fi
+
+if jq -e '(length == 2 and has("message") and has("request_id")) or has("error")' "$TARGET_DIR/$TARGET.tmp" > /dev/null; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API returned an error message, aborting"
+    exit 1
+fi
+
+mv "$TARGET_DIR/$TARGET.tmp" "$TARGET_DIR/$TARGET"
+
+MD5=$(md5sum "$TARGET_DIR/$TARGET" | cut -d' ' -f1)
+
+jq '. = [.[] | if (.id == "dataStaticGatheringNodes") then (.md5 = "'$MD5'") else . end]' < "$TARGET_DIR/../Data-Storage/urls.json" > "$TARGET_DIR/../Data-Storage/urls.json.tmp"
+mv "$TARGET_DIR/../Data-Storage/urls.json.tmp" "$TARGET_DIR/../Data-Storage/urls.json"

--- a/Generators/extract_map_camps.sh
+++ b/Generators/extract_map_camps.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TARGET_DIR=$(cd $(dirname "$0")/.. >/dev/null 2>&1 && pwd)/Reference
+
+if [ -z "${WYNNCRAFT_API_KEY:-}" ]; then
+    echo "Error: WYNNCRAFT_API_KEY is not set"
+    exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer ${WYNNCRAFT_API_KEY}"
+
+TARGET="map_camps.json"
+
+wget --header="$AUTH_HEADER" -O "$TARGET_DIR/$TARGET.tmp" "https://api.wynncraft.com/v3/map/camps"
+
+if [ ! -s "$TARGET_DIR/$TARGET.tmp" ]; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API is not working, aborting"
+    exit 1
+fi
+
+if jq -e '(length == 2 and has("message") and has("request_id")) or has("error")' "$TARGET_DIR/$TARGET.tmp" > /dev/null; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API returned an error message, aborting"
+    exit 1
+fi
+
+mv "$TARGET_DIR/$TARGET.tmp" "$TARGET_DIR/$TARGET"
+
+MD5=$(md5sum "$TARGET_DIR/$TARGET" | cut -d' ' -f1)
+
+jq '. = [.[] | if (.id == "dataStaticMapCamps") then (.md5 = "'$MD5'") else . end]' < "$TARGET_DIR/../Data-Storage/urls.json" > "$TARGET_DIR/../Data-Storage/urls.json.tmp"
+mv "$TARGET_DIR/../Data-Storage/urls.json.tmp" "$TARGET_DIR/../Data-Storage/urls.json"

--- a/Generators/extract_map_loot_pools.sh
+++ b/Generators/extract_map_loot_pools.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TARGET_DIR=$(cd $(dirname "$0")/.. >/dev/null 2>&1 && pwd)/Reference
+
+if [ -z "${WYNNCRAFT_API_KEY:-}" ]; then
+    echo "Error: WYNNCRAFT_API_KEY is not set"
+    exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer ${WYNNCRAFT_API_KEY}"
+
+TARGET="map_loot_pools.json"
+
+wget --header="$AUTH_HEADER" -O "$TARGET_DIR/$TARGET.tmp" "https://api.wynncraft.com/v3/map/loot-pools"
+
+if [ ! -s "$TARGET_DIR/$TARGET.tmp" ]; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API is not working, aborting"
+    exit 1
+fi
+
+if jq -e '(length == 2 and has("message") and has("request_id")) or has("error")' "$TARGET_DIR/$TARGET.tmp" > /dev/null; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API returned an error message, aborting"
+    exit 1
+fi
+
+mv "$TARGET_DIR/$TARGET.tmp" "$TARGET_DIR/$TARGET"
+
+MD5=$(md5sum "$TARGET_DIR/$TARGET" | cut -d' ' -f1)
+
+jq '. = [.[] | if (.id == "dataStaticMapLootPools") then (.md5 = "'$MD5'") else . end]' < "$TARGET_DIR/../Data-Storage/urls.json" > "$TARGET_DIR/../Data-Storage/urls.json.tmp"
+mv "$TARGET_DIR/../Data-Storage/urls.json.tmp" "$TARGET_DIR/../Data-Storage/urls.json"

--- a/Generators/extract_map_raids.sh
+++ b/Generators/extract_map_raids.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TARGET_DIR=$(cd $(dirname "$0")/.. >/dev/null 2>&1 && pwd)/Reference
+
+if [ -z "${WYNNCRAFT_API_KEY:-}" ]; then
+    echo "Error: WYNNCRAFT_API_KEY is not set"
+    exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer ${WYNNCRAFT_API_KEY}"
+
+TARGET="map_raids.json"
+
+wget --header="$AUTH_HEADER" -O "$TARGET_DIR/$TARGET.tmp" "https://api.wynncraft.com/v3/map/raids"
+
+if [ ! -s "$TARGET_DIR/$TARGET.tmp" ]; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API is not working, aborting"
+    exit 1
+fi
+
+if jq -e '(length == 2 and has("message") and has("request_id")) or has("error")' "$TARGET_DIR/$TARGET.tmp" > /dev/null; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API returned an error message, aborting"
+    exit 1
+fi
+
+mv "$TARGET_DIR/$TARGET.tmp" "$TARGET_DIR/$TARGET"
+
+MD5=$(md5sum "$TARGET_DIR/$TARGET" | cut -d' ' -f1)
+
+jq '. = [.[] | if (.id == "dataStaticMapRaids") then (.md5 = "'$MD5'") else . end]' < "$TARGET_DIR/../Data-Storage/urls.json" > "$TARGET_DIR/../Data-Storage/urls.json.tmp"
+mv "$TARGET_DIR/../Data-Storage/urls.json.tmp" "$TARGET_DIR/../Data-Storage/urls.json"

--- a/Generators/extract_world_events.sh
+++ b/Generators/extract_world_events.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TARGET_DIR=$(cd $(dirname "$0")/.. >/dev/null 2>&1 && pwd)/Reference
+
+if [ -z "${WYNNCRAFT_API_KEY:-}" ]; then
+    echo "Error: WYNNCRAFT_API_KEY is not set"
+    exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer ${WYNNCRAFT_API_KEY}"
+
+TARGET="world_events.json"
+
+wget --header="$AUTH_HEADER" -O "$TARGET_DIR/$TARGET.tmp" "https://api.wynncraft.com/v3/map/world-events"
+
+if [ ! -s "$TARGET_DIR/$TARGET.tmp" ]; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API is not working, aborting"
+    exit 1
+fi
+
+if jq -e '(length == 2 and has("message") and has("request_id")) or has("error")' "$TARGET_DIR/$TARGET.tmp" > /dev/null; then
+    rm "$TARGET_DIR/$TARGET.tmp"
+    echo "Error: Wynncraft API returned an error message, aborting"
+    exit 1
+fi
+
+mv "$TARGET_DIR/$TARGET.tmp" "$TARGET_DIR/$TARGET"
+
+MD5=$(md5sum "$TARGET_DIR/$TARGET" | cut -d' ' -f1)
+
+jq '. = [.[] | if (.id == "dataStaticWorldEvents") then (.md5 = "'$MD5'") else . end]' < "$TARGET_DIR/../Data-Storage/urls.json" > "$TARGET_DIR/../Data-Storage/urls.json.tmp"
+mv "$TARGET_DIR/../Data-Storage/urls.json.tmp" "$TARGET_DIR/../Data-Storage/urls.json"


### PR DESCRIPTION
Adds fetch scripts and scheduled GitHub Actions workflows for the five new Wynncraft map endpoints: `world-events`, `camps`, `raids`, `loot-pools`, and `gathering-nodes`. Registers the corresponding `dataStatic` entries in `urls.json`.